### PR TITLE
checks if username is taken in AccountSetup

### DIFF
--- a/src/components/SignUp/AccountSetup.tsx
+++ b/src/components/SignUp/AccountSetup.tsx
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet';
 import { withAlert } from 'react-alert';
 import Role from '../../static/Role';
 import { isValidUsername, isValidPassword } from '../../lib/Validations/Validations';
+import getServerURL from '../../serverOverride';
 
 interface Props {
   username: string,
@@ -48,7 +49,18 @@ class AccountSetup extends Component<Props, State, {}> {
   validateUsername = async ():Promise<void> => {
     const { username } = this.props;
     // ( if username is valid here and if username is taken)
-    if (isValidUsername(username)) {
+    const notTaken: boolean = await fetch(`${getServerURL()}/username-exists`, {
+      method: 'POST',
+      credentials: 'include',
+      body: JSON.stringify({
+        username: username,
+      }),
+    }).then((response) => response.json())
+      .then((responseJSON) => {
+        return (responseJSON['status'] === 'SUCCESS');
+      });
+
+    if (isValidUsername(username) && notTaken) {
       await new Promise((resolve) => this.setState({ usernameValidator: 'true' }, resolve));
     } else {
       await new Promise((resolve) => this.setState({ usernameValidator: 'false' }, resolve));

--- a/src/components/SignUp/AccountSetup.tsx
+++ b/src/components/SignUp/AccountSetup.tsx
@@ -57,7 +57,10 @@ class AccountSetup extends Component<Props, State, {}> {
       }),
     }).then((response) => response.json())
       .then((responseJSON) => {
-        return (responseJSON['status'] === 'SUCCESS');
+        const {
+          status
+        } = responseJSON;
+        return (status === 'SUCCESS');
       });
 
     if (isValidUsername(username) && notTaken) {


### PR DESCRIPTION
added validation checking if username is already taken in AccountSetup.
Addressed issue #29. 

in validateUsername function, fetches from backend whether username exists by checking if response json has SUCCESS status from /username-exists (matches pull request: [keepid/keepid_server/pull/37](url))