### PR TITLE
new PersonSignupFlow to replace PersonSignup, better role info & messages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ import Careers from './components/AboutUs/Careers';
 import AdminDashboard from './components/AdminDashboard';
 import Hubspot from './components/AboutUs/Hubspot';
 import InviteSignupJWT from './components/SignUp/InviteSignupJWT';
+import PersonSignupFlow from './components/SignUp/PersonSignupFlow';
 
 window.onload = () => {
   ReactGA.initialize('UA-176859431-1');
@@ -242,22 +243,22 @@ class App extends React.Component<{}, State, {}> {
                   switch (props.match.params.roleString) {
                     case 'admin':
                       return (role === Role.Director
-                        ? <PersonSignup userRole={role} personRole={Role.Admin} />
+                        ? <PersonSignupFlow userRole={role} personRole={Role.Admin} />
                         : <Redirect to="/error" />
                       );
                     case 'worker':
                       return (role === Role.Director || role === Role.Admin
-                        ? <PersonSignup userRole={role} personRole={Role.Worker} />
+                        ? <PersonSignupFlow userRole={role} personRole={Role.Worker} />
                         : <Redirect to="/error" />
                       );
                     case 'volunteer':
                       return (role === Role.Director || role === Role.Admin || role === Role.Worker
-                        ? <PersonSignup userRole={role} personRole={Role.Volunteer} />
+                        ? <PersonSignupFlow userRole={role} personRole={Role.Volunteer} />
                         : <Redirect to="/error" />
                       );
                     case 'client':
                       return (role === Role.Director || role === Role.Admin || role === Role.Worker || role === Role.Volunteer
-                        ? <PersonSignup userRole={role} personRole={Role.Client} />
+                        ? <PersonSignupFlow userRole={role} personRole={Role.Client} />
                         : <Redirect to="/error" />
                       );
                     default:

--- a/src/components/SignUp/AccountSetup.tsx
+++ b/src/components/SignUp/AccountSetup.tsx
@@ -131,6 +131,33 @@ class AccountSetup extends Component<Props, State, {}> {
       <div />
     );
   }
+  returnAccountMessage = (): ReactElement<{}> => {
+    switch (this.props.role) {
+      case Role.Admin: {
+        return (
+        <div>
+        Admins can set up accounts for
+        <br />
+        {' '}
+        other workers in the organization and for clients.
+        {' '}
+      </div>);
+      }
+      case Role.Director, Role.Worker, Role.Volunteer: {
+        return (
+          <div>
+          {`${this.props.role}s`} can set up 
+          <br />
+          {' '}
+          accounts for clients.
+          {' '}
+        </div>); 
+      }
+      default: {
+          return <div></div>;
+      }
+    }
+  }
 
   handleStepComplete = async (e) => {
     await Promise.all([this.validateUsername(), this.validatePassword(), this.validateConfirmPassword()]);
@@ -168,9 +195,10 @@ class AccountSetup extends Component<Props, State, {}> {
         <div className="d-flex justify-content-center pt-5">
           <div className="col-md-8">
             <div className="text-center pb-4 mb-2">
-              <h2><b>First, set up your account information</b></h2>
+              <h2><b>First, set up the {this.props.role} account login.</b></h2>
               <span>
-                You will be the
+                {this.returnAccountMessage()} 
+                {/* You will be the
                 {' '}
                 {this.props.role}
                 {' '}
@@ -188,7 +216,7 @@ class AccountSetup extends Component<Props, State, {}> {
                       {' '}
                     </div>
                   )
-                  : <div>you can set up accounts for clients</div>}
+                  : <div>you can set up accounts for clients</div>} */}
               </span>
             </div>
             <form onSubmit={this.handleStepComplete}>

--- a/src/components/SignUp/AccountSetup.tsx
+++ b/src/components/SignUp/AccountSetup.tsx
@@ -131,30 +131,31 @@ class AccountSetup extends Component<Props, State, {}> {
       <div />
     );
   }
-  returnAccountMessage = (): ReactElement<{}> => {
+  returnAccountMessage = () => {
     switch (this.props.role) {
       case Role.Admin: {
         return (
-        <div>
-        Admins can set up accounts for
-        <br />
-        {' '}
-        other workers in the organization and for clients.
-        {' '}
-      </div>);
+          <div>
+          Admins can set up accounts for
+          <br />
+          {' '}
+          other workers in the organization and for clients.
+          {' '}
+          </div>);
       }
-      case Role.Director, Role.Worker, Role.Volunteer: {
+      case Role.Director: case Role.Worker: case Role.Volunteer: {
         return (
           <div>
-          {`${this.props.role}s`} can set up 
+          {`${this.props.role}s`}
+          can set up 
           <br />
           {' '}
           accounts for clients.
           {' '}
-        </div>); 
+        </div>);
       }
       default: {
-          return <div></div>;
+        return <div />;
       }
     }
   }
@@ -195,28 +196,11 @@ class AccountSetup extends Component<Props, State, {}> {
         <div className="d-flex justify-content-center pt-5">
           <div className="col-md-8">
             <div className="text-center pb-4 mb-2">
-              <h2><b>First, set up the {this.props.role} account login.</b></h2>
+              <h2><b>
+                First, set up the {this.props.role} account login.
+              </b></h2>
               <span>
-                {this.returnAccountMessage()} 
-                {/* You will be the
-                {' '}
-                {this.props.role}
-                {' '}
-                of your organization. As the
-                {' '}
-                {this.props.role}
-                ,
-                {this.props.role === Role.Admin
-                  ? (
-                    <div>
-                      you can set up accounts for
-                      <br />
-                      {' '}
-                      other workers in the organization and for your clients.
-                      {' '}
-                    </div>
-                  )
-                  : <div>you can set up accounts for clients</div>} */}
+                {this.returnAccountMessage()}
               </span>
             </div>
             <form onSubmit={this.handleStepComplete}>

--- a/src/components/SignUp/AccountSetup.tsx
+++ b/src/components/SignUp/AccountSetup.tsx
@@ -131,28 +131,31 @@ class AccountSetup extends Component<Props, State, {}> {
       <div />
     );
   }
+
   returnAccountMessage = () => {
     switch (this.props.role) {
       case Role.Admin: {
         return (
           <div>
-          Admins can set up accounts for
-          <br />
-          {' '}
-          other workers in the organization and for clients.
-          {' '}
-          </div>);
+            Admins can set up accounts for
+            <br />
+            {' '}
+            other workers in the organization and for clients.
+            {' '}
+          </div>
+        );
       }
       case Role.Director: case Role.Worker: case Role.Volunteer: {
         return (
           <div>
-          {`${this.props.role}s`}
-          can set up 
-          <br />
-          {' '}
-          accounts for clients.
-          {' '}
-        </div>);
+            {`${this.props.role}s`}
+            can set up
+            <br />
+            {' '}
+            accounts for clients.
+            {' '}
+          </div>
+        );
       }
       default: {
         return <div />;
@@ -196,9 +199,13 @@ class AccountSetup extends Component<Props, State, {}> {
         <div className="d-flex justify-content-center pt-5">
           <div className="col-md-8">
             <div className="text-center pb-4 mb-2">
-              <h2><b>
-                First, set up the {this.props.role} account login.
-              </b></h2>
+              <h2>
+                <b>
+                First, set up the
+                {this.props.role}
+                account login.
+                </b>
+              </h2>
               <span>
                 {this.returnAccountMessage()}
               </span>

--- a/src/components/SignUp/CompleteSignupFlow.tsx
+++ b/src/components/SignUp/CompleteSignupFlow.tsx
@@ -5,7 +5,6 @@ import { withAlert } from 'react-alert';
 import { Steps } from 'antd';
 import { ProgressBar } from 'react-bootstrap';
 import getServerURL from '../../serverOverride';
-// import Logo from '../../static/images/logo.svg';
 import 'antd/dist/antd.css'; // or 'antd/dist/antd.less'
 import AccountSetup from './AccountSetup';
 import PersonalInformation from './PersonalInformation';

--- a/src/components/SignUp/InviteSignupJWT.tsx
+++ b/src/components/SignUp/InviteSignupJWT.tsx
@@ -6,7 +6,7 @@ import InviteSignupFlow from './InviteSignupFlow';
 const jwtDecode = require('jwt-decode');
 
 function InviteSignupJWT() {
-  const { jwt } = useParams();
+  const { jwt }: any = useParams();
   try {
     const decoded = jwtDecode(jwt);
     const currentTime = Date.now() / 1000;

--- a/src/components/SignUp/PersonSignupFlow.tsx
+++ b/src/components/SignUp/PersonSignupFlow.tsx
@@ -137,7 +137,6 @@ class PersonSignupFlow extends Component<Props, State, {}> {
         username,
         password,
         personRole,
-        //orgName,
         recaptchaPayload,
       }),
     }).then((response) => response.json())

--- a/src/components/SignUp/PersonSignupFlow.tsx
+++ b/src/components/SignUp/PersonSignupFlow.tsx
@@ -12,15 +12,16 @@ import PersonalInformation from './PersonalInformation';
 import SignUserAgreement from './SignUserAgreement';
 import ReviewSubmitInviteSignupVersion from './ReviewSubmitInviteSignupVersion';
 import Role from '../../static/Role';
+import ReviewSubmit from './ReviewSubmit';
 
 const { Step } = Steps;
 
 interface Props {
   alert: any,
-  orgName: string,
   personRole: Role,
+  //invited: boolean
+  //orgName: string,for generalizing to invite
 }
-
 interface State {
   signupStage: number,
   username: string,
@@ -38,10 +39,10 @@ interface State {
   hasSigned: boolean,
   recaptchaPayload: string,
   buttonState: string,
-  redirectLogin: boolean
+  redirectLogin: boolean,
 }
 
-class InviteSignupFlow extends Component<Props, State, {}> {
+class PersonSignupFlow extends Component<Props, State, {}> {
   static birthDateStringConverter = (birthDate: Date):string => {
     const personBirthMonth = birthDate.getMonth() + 1;
     const personBirthMonthString = (personBirthMonth < 10 ? `0${personBirthMonth}` : personBirthMonth);
@@ -73,6 +74,10 @@ class InviteSignupFlow extends Component<Props, State, {}> {
       redirectLogin: false,
     };
   }
+  // static defaultProps = {
+  //   orgName: "",
+  //   invited: false
+  // }
 
   handleChangeUsername = (e: { target: { value: string; }; }) => this.setState({ username: e.target.value });
 
@@ -127,11 +132,10 @@ class InviteSignupFlow extends Component<Props, State, {}> {
       email,
       recaptchaPayload,
     } = this.state;
-    const { orgName, alert, personRole } = this.props;
-    const birthDateString = InviteSignupFlow.birthDateStringConverter(birthDate);
-    // submit user information
-
-    fetch(`${getServerURL()}/create-invited-user`, {
+    const { alert, personRole } = this.props;
+    const birthDateString = PersonSignupFlow.birthDateStringConverter(birthDate);
+    //const slug = this.props.invited ? "create-invited-user" : "create-user";
+    fetch(`${getServerURL()}/create-user`, {
       method: 'POST',
       credentials: 'include',
       body: JSON.stringify({
@@ -148,7 +152,7 @@ class InviteSignupFlow extends Component<Props, State, {}> {
         username,
         password,
         personRole,
-        orgName,
+        //orgName,
         recaptchaPayload,
       }),
     }).then((response) => response.json())
@@ -160,7 +164,7 @@ class InviteSignupFlow extends Component<Props, State, {}> {
 
         if (status === 'ENROLL_SUCCESS') {
           this.setState({ buttonState: '' });
-          alert.show('You successfully signed up to use Keep.id. Please login with your new username and password');
+          alert.show(`Successful ${this.props.personRole} signup to use Keep.id. You can login with the new username and password`);
           this.setState({ redirectLogin: true });
         } else if (status === 'INVALID_PARAMETER') {
           this.setState({ buttonState: '' });
@@ -315,5 +319,5 @@ class InviteSignupFlow extends Component<Props, State, {}> {
   }
 }
 
-export const { birthDateStringConverter } = InviteSignupFlow;
-export default withAlert()(InviteSignupFlow);
+export const { birthDateStringConverter } = PersonSignupFlow;
+export default withAlert()(PersonSignupFlow);

--- a/src/components/SignUp/PersonSignupFlow.tsx
+++ b/src/components/SignUp/PersonSignupFlow.tsx
@@ -1,27 +1,25 @@
-import React, { Component, ReactComponentElement } from 'react';
+import React, { Component } from 'react';
 import { Redirect } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import { withAlert } from 'react-alert';
 import { Steps } from 'antd';
 import { ProgressBar } from 'react-bootstrap';
 import getServerURL from '../../serverOverride';
-// import Logo from '../../static/images/logo.svg';
 import 'antd/dist/antd.css'; // or 'antd/dist/antd.less'
 import AccountSetup from './AccountSetup';
 import PersonalInformation from './PersonalInformation';
 import SignUserAgreement from './SignUserAgreement';
 import ReviewSubmitInviteSignupVersion from './ReviewSubmitInviteSignupVersion';
 import Role from '../../static/Role';
-import ReviewSubmit from './ReviewSubmit';
+import { birthDateStringConverter } from './CompleteSignupFlow';
 
 const { Step } = Steps;
 
 interface Props {
   alert: any,
   personRole: Role,
-  //invited: boolean
-  //orgName: string,for generalizing to invite
 }
+
 interface State {
   signupStage: number,
   username: string,
@@ -43,14 +41,6 @@ interface State {
 }
 
 class PersonSignupFlow extends Component<Props, State, {}> {
-  static birthDateStringConverter = (birthDate: Date):string => {
-    const personBirthMonth = birthDate.getMonth() + 1;
-    const personBirthMonthString = (personBirthMonth < 10 ? `0${personBirthMonth}` : personBirthMonth);
-    const personBirthDay = birthDate.getDate();
-    const personBirthDayString = (personBirthDay < 10 ? `0${personBirthDay}` : personBirthDay);
-    const personBirthDateFormatted = `${personBirthMonthString}-${personBirthDayString}-${birthDate.getFullYear()}`;
-    return personBirthDateFormatted;
-  }
 
   constructor(props: Props) {
     super(props);
@@ -74,10 +64,6 @@ class PersonSignupFlow extends Component<Props, State, {}> {
       redirectLogin: false,
     };
   }
-  // static defaultProps = {
-  //   orgName: "",
-  //   invited: false
-  // }
 
   handleChangeUsername = (e: { target: { value: string; }; }) => this.setState({ username: e.target.value });
 
@@ -133,8 +119,7 @@ class PersonSignupFlow extends Component<Props, State, {}> {
       recaptchaPayload,
     } = this.state;
     const { alert, personRole } = this.props;
-    const birthDateString = PersonSignupFlow.birthDateStringConverter(birthDate);
-    //const slug = this.props.invited ? "create-invited-user" : "create-user";
+    const birthDateString = birthDateStringConverter(birthDate);
     fetch(`${getServerURL()}/create-user`, {
       method: 'POST',
       credentials: 'include',
@@ -319,5 +304,4 @@ class PersonSignupFlow extends Component<Props, State, {}> {
   }
 }
 
-export const { birthDateStringConverter } = PersonSignupFlow;
 export default withAlert()(PersonSignupFlow);

--- a/src/components/SignUp/PersonalInformation.tsx
+++ b/src/components/SignUp/PersonalInformation.tsx
@@ -249,7 +249,7 @@ class PersonalInformation extends Component<Props, State, {}> {
         <div className="d-flex justify-content-center pt-5">
           <div className="col-md-10">
             <div className="text-center pb-4 mb-2">
-              <h2><b>Next, tell us about yourself</b></h2>
+              <h2><b>Next, add in some contact information.</b></h2>
             </div>
             <form onSubmit={this.handleStepComplete}>
               <div className="form-group row">

--- a/src/static/Role.tsx
+++ b/src/static/Role.tsx
@@ -1,10 +1,10 @@
 enum Role {
-    Director = "Director", // can delete admin and create admin
-    Admin = "Admin",
-    Worker = "Worker",
-    Volunteer = "Volunteer",
-    Client = "Client",
-    LoggedOut = "Logged-Out User",
+    Director = 'Director',
+    Admin = 'Admin',
+    Worker = 'Worker',
+    Volunteer = 'Volunteer',
+    Client = 'Client',
+    LoggedOut = 'Logged-Out User',
 }
 
 export default Role;

--- a/src/static/Role.tsx
+++ b/src/static/Role.tsx
@@ -1,10 +1,10 @@
 enum Role {
-    Director, // can delete admin and create admin
-    Admin,
-    Worker,
-    Volunteer,
-    Client,
-    LoggedOut,
+    Director = "Director", // can delete admin and create admin
+    Admin = "Admin",
+    Worker = "Worker",
+    Volunteer = "Volunteer",
+    Client = "Client",
+    LoggedOut = "Logged-Out User",
 }
 
 export default Role;


### PR DESCRIPTION
From Issue #38 :
- created PersonSignupFlow to replace PersonSignup in App.tsx, follows InviteSignupFlow format
- modified enums in Role so roles won't default appear as numbers
- modified header instructions in AccountSetup (this.returnAccountMessage()) and PersonalInformation so it'll have role names + be in 3rd person (weird if Admin is signing up a client/worker and it says "your personal info")
- changed header of signup-flow steps, in PersonSignupFlow & InviteSignupFlow, to have "{role} Account Setup" so it's clear what kind of user is being signed up
- commented out some code that can be used to combine invite flow with this case, can do in future
- note: didn't delete PersonSignup file yet