### PR TITLE
AccountSetup message typo

### DIFF
--- a/src/components/SignUp/AccountSetup.tsx
+++ b/src/components/SignUp/AccountSetup.tsx
@@ -202,7 +202,9 @@ class AccountSetup extends Component<Props, State, {}> {
               <h2>
                 <b>
                 First, set up the
+                {" "}
                 {this.props.role}
+                {" "}
                 account login.
                 </b>
               </h2>


### PR DESCRIPTION
There weren't spaces between "the[ ]{role}[ ]account" login message in AccountSetup!