### PR TITLE
In ApplicationForm.tsx, update progress bar based on questions answered

### DIFF
--- a/src/components/PDF/ApplicationForm.tsx
+++ b/src/components/PDF/ApplicationForm.tsx
@@ -1,4 +1,4 @@
-import React, { Component, useState } from 'react';
+import React, { Component } from 'react';
 import { Helmet } from 'react-helmet';
 import { Link, Redirect } from 'react-router-dom';
 import { withAlert } from 'react-alert';
@@ -30,7 +30,7 @@ interface State {
 
 // Source: https://stackoverflow.com/questions/4998908/convert-data-uri-to-file-then-append-to-formdata
 function dataURLtoBlob(dataurl) {
-  const arr = dataurl.split(','); const mime = arr[0].match(/:(.*?);/)[1];
+  const arr = dataurl.split(','); // const mime = arr[0].match(/:(.*?);/)[1];
   const bstr = atob(arr[1]); let n = bstr.length; const
     u8arr = new Uint8Array(n);
   while (n >= 0) {
@@ -182,6 +182,16 @@ class ApplicationForm extends Component<Props, State> {
     }
   }
 
+  progressBarFill() {
+    const { formQuestions, formAnswers } = this.state;
+    const total = (formQuestions) ? formQuestions.length : 0;
+    let answered = 0;
+    Object.keys(formAnswers).forEach((questionId) => {
+      if (formAnswers[questionId]) answered += 1;
+    });
+    return (total === 0) ? 100 : Math.round((answered / total) * 100);
+  }
+
   render() {
     const {
       pdfApplication,
@@ -198,12 +208,13 @@ class ApplicationForm extends Component<Props, State> {
     }
 
     let bodyElement;
+    const fillAmt = this.progressBarFill();
     if (pdfApplication) {
       bodyElement = (
         <div className="col-lg-10 col-md-12 col-sm-12 mx-auto">
           <div className="jumbotron jumbotron-fluid bg-white pb-0 text-center">
             <div className="progress mb-4">
-              <div className="progress-bar" role="progressbar" aria-valuenow={75} aria-valuemin={0} aria-valuemax={100} style={{ width: '90%' }} />
+              <div className="progress-bar active" role="progressbar" aria-valuenow={fillAmt} aria-valuemin={0} aria-valuemax={100} style={{ width: `${fillAmt}%` }}>{`${fillAmt}%`}</div>
             </div>
             <div className="container">
               <h2>Review and sign to complete your form</h2>
@@ -242,7 +253,7 @@ class ApplicationForm extends Component<Props, State> {
         <div className="col-lg-10 col-md-12 col-sm-12 mx-auto">
           <div className="jumbotron jumbotron-fluid bg-white pb-0 text-center">
             <div className="progress mb-4">
-              <div className="progress-bar" role="progressbar" aria-valuenow={75} aria-valuemin={0} aria-valuemax={100} style={{ width: '75%' }} />
+              <div className="progress-bar" role="progressbar" aria-valuenow={fillAmt} aria-valuemin={0} aria-valuemax={100} style={{ width: `${fillAmt}%` }}>{`${fillAmt}%`}</div>
             </div>
             <div className="container col-lg-10 col-md-10 col-sm-12">
               <h2>Application Form Name</h2>

--- a/src/components/PDF/ApplicationForm.tsx
+++ b/src/components/PDF/ApplicationForm.tsx
@@ -30,7 +30,7 @@ interface State {
 
 // Source: https://stackoverflow.com/questions/4998908/convert-data-uri-to-file-then-append-to-formdata
 function dataURLtoBlob(dataurl) {
-  const arr = dataurl.split(','); // const mime = arr[0].match(/:(.*?);/)[1];
+  const arr = dataurl.split(',');
   const bstr = atob(arr[1]); let n = bstr.length; const
     u8arr = new Uint8Array(n);
   while (n >= 0) {
@@ -182,7 +182,7 @@ class ApplicationForm extends Component<Props, State> {
     }
   }
 
-  progressBarFill() {
+  progressBarFill = (): number => {
     const { formQuestions, formAnswers } = this.state;
     const total = (formQuestions) ? formQuestions.length : 0;
     let answered = 0;


### PR DESCRIPTION
- made progressBarFill() function that calculates percent amt of questions answered based on total number of questions, to be used in the progress-bar divs in the render()
- rounds to whole number
- backtracks if input is removed
- also display percent number, can remove if needed
- realized that page numbers are just 0 out of 0? not sure if that is a bug or I just didn't pull since starting this branch

![image](https://user-images.githubusercontent.com/21111373/97813203-82124c80-1c54-11eb-8dad-694c39759259.png)
