### PR TITLE
remove non-US states from json

### DIFF
--- a/src/static/data/states_titlecase.json
+++ b/src/static/data/states_titlecase.json
@@ -1,5 +1,4 @@
-[
-    {
+[{
         "name": "No State Selected",
         "abbreviation": "No State Selected"
     },
@@ -10,10 +9,6 @@
     {
         "name": "Alaska",
         "abbreviation": "AK"
-    },
-    {
-        "name": "American Samoa",
-        "abbreviation": "AS"
     },
     {
         "name": "Arizona",
@@ -44,20 +39,12 @@
         "abbreviation": "DC"
     },
     {
-        "name": "Federated States Of Micronesia",
-        "abbreviation": "FM"
-    },
-    {
         "name": "Florida",
         "abbreviation": "FL"
     },
     {
         "name": "Georgia",
         "abbreviation": "GA"
-    },
-    {
-        "name": "Guam",
-        "abbreviation": "GU"
     },
     {
         "name": "Hawaii",
@@ -94,10 +81,6 @@
     {
         "name": "Maine",
         "abbreviation": "ME"
-    },
-    {
-        "name": "Marshall Islands",
-        "abbreviation": "MH"
     },
     {
         "name": "Maryland",
@@ -160,10 +143,6 @@
         "abbreviation": "ND"
     },
     {
-        "name": "Northern Mariana Islands",
-        "abbreviation": "MP"
-    },
-    {
         "name": "Ohio",
         "abbreviation": "OH"
     },
@@ -176,16 +155,8 @@
         "abbreviation": "OR"
     },
     {
-        "name": "Palau",
-        "abbreviation": "PW"
-    },
-    {
         "name": "Pennsylvania",
         "abbreviation": "PA"
-    },
-    {
-        "name": "Puerto Rico",
-        "abbreviation": "PR"
     },
     {
         "name": "Rhode Island",
@@ -214,10 +185,6 @@
     {
         "name": "Vermont",
         "abbreviation": "VT"
-    },
-    {
-        "name": "Virgin Islands",
-        "abbreviation": "VI"
     },
     {
         "name": "Virginia",


### PR DESCRIPTION
See Issue #78 
Avoid invalid State error on My Account Settings, when setting the US state, because front-end json included Northern Mariana Islands (MP) and other territories as US states, but backend validation didn't account for anything outside the 50 states. Removed those territories from states_titlecase.json