### PR TITLE
Application Form: added button & page num logic

### DIFF
--- a/src/components/PDF/ApplicationForm.tsx
+++ b/src/components/PDF/ApplicationForm.tsx
@@ -184,7 +184,8 @@ class ApplicationForm extends Component<Props, State> {
         this.setState({
           pdfApplication: pdfFile,
           buttonState: '',
-        });
+        },
+        () => window.scrollTo(0, 0));
       });
   }
 

--- a/src/components/PDF/ApplicationForm.tsx
+++ b/src/components/PDF/ApplicationForm.tsx
@@ -3,12 +3,12 @@ import { Helmet } from 'react-helmet';
 import { Link, Redirect } from 'react-router-dom';
 import { withAlert } from 'react-alert';
 import DatePicker from 'react-datepicker';
+import uuid from 'react-uuid';
 import getServerURL from '../../serverOverride';
 import DocumentViewer from './DocumentViewer';
 import PDFType from '../../static/PDFType';
 import SignaturePad from '../../lib/SignaturePad';
 import 'react-datepicker/dist/react-datepicker.css';
-import uuid from 'react-uuid';
 // import {Simulate} from "react-dom/test-utils";
 // import submit = Simulate.submit;
 
@@ -86,10 +86,11 @@ class ApplicationForm extends Component<Props, State> {
         const { status } = responseJSON;
         if (status === 'SUCCESS') {
           const { fields } = responseJSON;
-          this.setState({ formQuestions: fields,
-                          numPages:
-                          (fields.length === 0) ? 1 : Math.ceil(fields.length/MAX_Q_PER_PAGE),
-                        });
+          this.setState({
+            formQuestions: fields,
+            numPages:
+            (fields.length === 0) ? 1 : Math.ceil(fields.length / MAX_Q_PER_PAGE),
+          });
           fields.forEach((entry) => {
             formAnswers[entry.fieldName] = entry.fieldDefaultValue;
           });
@@ -109,7 +110,7 @@ class ApplicationForm extends Component<Props, State> {
 
   handlePrevious = (e:any): void => {
     e.preventDefault();
-    this.setState((prevState) => ({ currentPage: prevState.currentPage - 1 }));
+    this.setState((prevState) => ({ currentPage: prevState.currentPage - 1 }), () => window.scrollTo(0, 0));
   }
 
   handleChangeFormValueTextField(event: any) {
@@ -180,8 +181,10 @@ class ApplicationForm extends Component<Props, State> {
     }).then((response) => response.blob())
       .then((responseBlob) => {
         const pdfFile = new File([responseBlob], applicationFilename, { type: 'application/pdf' });
-        this.setState({ pdfApplication: pdfFile,
-                        buttonState: '' });
+        this.setState({
+          pdfApplication: pdfFile,
+          buttonState: '',
+        });
       });
   }
 
@@ -190,7 +193,7 @@ class ApplicationForm extends Component<Props, State> {
       pdfApplication,
     } = this.state;
     const {
-      alert
+      alert,
     } = this.props;
     if (pdfApplication) {
       const formData = new FormData();
@@ -217,7 +220,7 @@ class ApplicationForm extends Component<Props, State> {
     let answered = 0;
     Object.keys(formAnswers).forEach((questionId) => {
       const ans = formAnswers[questionId];
-      if (ans && ans !== 'Off' && ans !== 'false')  {
+      if (ans && ans !== 'Off' && ans !== 'false') {
         answered += 1;
       }
     });
@@ -242,15 +245,13 @@ class ApplicationForm extends Component<Props, State> {
     }
 
     let bodyElement;
-    const fillAmt = this.progressBarFill();
-    const qStartNum = (currentPage-1) * MAX_Q_PER_PAGE;
+    const fillAmt = (currentPage / numPages) * 100;
+    // const fillAmt = this.progressBarFill();
+    const qStartNum = (currentPage - 1) * MAX_Q_PER_PAGE;
     if (pdfApplication) {
       bodyElement = (
         <div className="col-lg-10 col-md-12 col-sm-12 mx-auto">
           <div className="jumbotron jumbotron-fluid bg-white pb-0 text-center">
-            <div className="progress mb-4">
-              <div className="progress-bar active" role="progressbar" aria-valuenow={fillAmt} aria-valuemin={0} aria-valuemax={100} style={{ width: `${fillAmt}%` }}>{`${fillAmt}%`}</div>
-            </div>
             <div className="container">
               <h2>Review and sign to complete your form</h2>
               <p>Finally, sign the agreement and click submit when complete.</p>
@@ -263,7 +264,7 @@ class ApplicationForm extends Component<Props, State> {
               <div className="pt-5 pb-3">I agree to all terms and conditions in the agreement above.</div>
               <SignaturePad ref={(ref) => { this.signaturePad = ref; }} />
               <div className="d-flex text-center my-5">
-                <button type="submit" className={`ml-auto btn btn-primary loginButtonBackground`} onClick={this.onSubmitPdfApplication}>Submit PDF</button>
+                <button type="submit" className="ml-auto btn btn-primary loginButtonBackground" onClick={this.onSubmitPdfApplication}>Submit PDF</button>
               </div>
             </div>
           </div>
@@ -274,7 +275,7 @@ class ApplicationForm extends Component<Props, State> {
         <div className="col-lg-10 col-md-12 col-sm-12 mx-auto">
           <div className="jumbotron jumbotron-fluid bg-white pb-0 text-center">
             <div className="progress mb-4">
-              <div className="progress-bar" role="progressbar" aria-valuenow={fillAmt} aria-valuemin={0} aria-valuemax={100} style={{ width: `${fillAmt}%` }}>{`${fillAmt}%`}</div>
+              <div className="progress-bar" role="progressbar" aria-valuenow={fillAmt} aria-valuemin={0} aria-valuemax={100} style={{ width: `${fillAmt}%` }} />
             </div>
             <div className="container col-lg-10 col-md-10 col-sm-12">
               <h2>Application Form Name</h2>
@@ -283,15 +284,14 @@ class ApplicationForm extends Component<Props, State> {
           </div>
           <div className="container border px-5 col-lg-10 col-md-10 col-sm-12">
             <form onSubmit={this.onSubmitFormQuestions}>
-              
               {formQuestions.map(
                 (entry, index) => {
-                  if (index < qStartNum || index >= qStartNum+MAX_Q_PER_PAGE) return null;
+                  if (index < qStartNum || index >= qStartNum + MAX_Q_PER_PAGE) return null;
                   const currValue = formAnswers[entry.fieldName];
-                  
+
                   return (
-                  <div className="my-5" key={uuid()}>
-                    {
+                    <div className="my-5" key={uuid()}>
+                      {
                       (() => {
                         if (entry.fieldType === 'TextField') {
                           return (
@@ -382,7 +382,7 @@ class ApplicationForm extends Component<Props, State> {
                               </label>
 
                               <select defaultValue={selectedVal} id={entry.fieldName} onChange={this.handleChangeFormValueTextField} className="custom-select" required>
-                                <option disabled value='defaultValue'>Please select your choice ...</option>
+                                <option disabled value="defaultValue">Please select your choice ...</option>
                                 {temp.map((value) => (
                                   <option value={value} key={value}>{value}</option>
                                 ))}
@@ -430,8 +430,9 @@ class ApplicationForm extends Component<Props, State> {
                         return <div />;
                       })()
                     }
-                  </div>
-                )},
+                    </div>
+                  );
+                },
               )}
 
               <div className="row justify-content-between text-center my-5">
@@ -451,14 +452,15 @@ class ApplicationForm extends Component<Props, State> {
                     </b>
                   </p>
                 </div>
-                <div className='col-md-2 mr-xs-3 mr-sm-0'>
-                  { (currentPage !== numPages)
+                <div className="col-md-2 mr-xs-3 mr-sm-0">
+                  {(currentPage !== numPages)
                     ? <button type="submit" className="btn btn-primary" onClick={this.handleContinue}>Continue</button>
-                    : <button type="submit" className={`btn btn-success loginButtonBackground ld-ext-right ${buttonState}`} onClick={this.onSubmitFormQuestions}>
+                    : (
+                      <button type="submit" className={`btn btn-success loginButtonBackground ld-ext-right ${buttonState}`} onClick={this.onSubmitFormQuestions}>
                         Submit
                         <div className="ld ld-ring ld-spin" />
                       </button>
-                  }
+                    )}
                 </div>
               </div>
             </form>

--- a/src/components/PDF/ApplicationForm.tsx
+++ b/src/components/PDF/ApplicationForm.tsx
@@ -8,6 +8,7 @@ import DocumentViewer from './DocumentViewer';
 import PDFType from '../../static/PDFType';
 import SignaturePad from '../../lib/SignaturePad';
 import 'react-datepicker/dist/react-datepicker.css';
+import uuid from 'react-uuid';
 // import {Simulate} from "react-dom/test-utils";
 // import submit = Simulate.submit;
 
@@ -179,7 +180,8 @@ class ApplicationForm extends Component<Props, State> {
     }).then((response) => response.blob())
       .then((responseBlob) => {
         const pdfFile = new File([responseBlob], applicationFilename, { type: 'application/pdf' });
-        this.setState({ pdfApplication: pdfFile });
+        this.setState({ pdfApplication: pdfFile,
+                        buttonState: '' });
       });
   }
 
@@ -232,6 +234,7 @@ class ApplicationForm extends Component<Props, State> {
       numPages,
       startDate,
       formError,
+      buttonState,
     } = this.state;
 
     if (submitSuccessful) {
@@ -242,7 +245,6 @@ class ApplicationForm extends Component<Props, State> {
     const fillAmt = this.progressBarFill();
     const qStartNum = (currentPage-1) * MAX_Q_PER_PAGE;
     if (pdfApplication) {
-      console.log('PDF APPLICATION!!!!');
       bodyElement = (
         <div className="col-lg-10 col-md-12 col-sm-12 mx-auto">
           <div className="jumbotron jumbotron-fluid bg-white pb-0 text-center">
@@ -261,21 +263,7 @@ class ApplicationForm extends Component<Props, State> {
               <div className="pt-5 pb-3">I agree to all terms and conditions in the agreement above.</div>
               <SignaturePad ref={(ref) => { this.signaturePad = ref; }} />
               <div className="d-flex text-center my-5">
-                {(currentPage === 1) ? null : <button type="button" className="btn btn-outline-primary mr-auto">Previous Step</button>}
-                <span>
-                  <p>
-                    <b>
-                      Page
-                      {' '}
-                      {currentPage}
-                      {' '}
-                      of
-                      {' '}
-                      {numPages}
-                    </b>
-                  </p>
-                </span>
-                <button type="submit" className="ml-auto btn btn-primary ml-auto" onClick={this.onSubmitPdfApplication}>Submit PDF</button>
+                <button type="submit" className={`ml-auto btn btn-primary loginButtonBackground`} onClick={this.onSubmitPdfApplication}>Submit PDF</button>
               </div>
             </div>
           </div>
@@ -302,7 +290,7 @@ class ApplicationForm extends Component<Props, State> {
                   const currValue = formAnswers[entry.fieldName];
                   
                   return (
-                  <div className="my-5" key={index}>
+                  <div className="my-5" key={uuid()}>
                     {
                       (() => {
                         if (entry.fieldType === 'TextField') {
@@ -445,13 +433,12 @@ class ApplicationForm extends Component<Props, State> {
                   </div>
                 )},
               )}
-              {/* <button type="submit" className={`mt-2 btn btn-success loginButtonBackground ld-ext-right ${this.state.buttonState}`}>
-                Submit Form Answers
-                <div className="ld ld-ring ld-spin" />
-              </button> */}
-              <div className="d-flex text-center my-5">
-              {(currentPage === 1) ? <div /> : <button type="button" className="btn btn-outline-primary mr-auto" onClick={this.handlePrevious}>Previous</button>}
-                <span>
+
+              <div className="row justify-content-between text-center my-5">
+                <div className="col-md-2 pl-0">
+                  {(currentPage === 1) ? null : <button type="button" className="mr-auto btn btn-outline-primary" onClick={this.handlePrevious}>Previous</button>}
+                </div>
+                <div className="col-md-4 text-center my-1">
                   <p>
                     <b>
                       Page
@@ -463,12 +450,16 @@ class ApplicationForm extends Component<Props, State> {
                       {numPages}
                     </b>
                   </p>
-                </span>
-                
-                { (currentPage !== numPages)
-                  ? <button type="submit" className="ml-auto btn btn-primary ml-auto" onClick={this.handleContinue}>Continue</button>
-                  : <button type="submit" disabled={fillAmt !== 100} className="ml-auto btn btn-primary ml-auto" onClick={this.onSubmitFormQuestions}>Submit</button>
-                }
+                </div>
+                <div className='col-md-2 mr-xs-3 mr-sm-0'>
+                  { (currentPage !== numPages)
+                    ? <button type="submit" className="btn btn-primary" onClick={this.handleContinue}>Continue</button>
+                    : <button type="submit" className={`btn btn-success loginButtonBackground ld-ext-right ${buttonState}`} onClick={this.onSubmitFormQuestions}>
+                        Submit
+                        <div className="ld ld-ring ld-spin" />
+                      </button>
+                  }
+                </div>
               </div>
             </form>
           </div>

--- a/src/components/PDF/ApplicationForm.tsx
+++ b/src/components/PDF/ApplicationForm.tsx
@@ -275,7 +275,7 @@ class ApplicationForm extends Component<Props, State> {
         <div className="col-lg-10 col-md-12 col-sm-12 mx-auto">
           <div className="jumbotron jumbotron-fluid bg-white pb-0 text-center">
             <div className="progress mb-4">
-              <div className="progress-bar" role="progressbar" aria-valuenow={fillAmt} aria-valuemin={0} aria-valuemax={100} style={{ width: `${fillAmt}%` }} />
+              <div className="progress-bar" role="progressbar" aria-valuenow={fillAmt} aria-valuemin={0} aria-valuemax={100} aria-label={`${fillAmt}%`} style={{ width: `${fillAmt}%` }} />
             </div>
             <div className="container col-lg-10 col-md-10 col-sm-12">
               <h2>Application Form Name</h2>


### PR DESCRIPTION
#81 , #129 (still WIP)
- **broke up q's into pages!!** had to play around to get questions to maintain prev-recorded answers
    - MAX_Q_PER_PAGE set to 10, so there are 10 questions per page (**does that look okay?**)
    - Previous button not there when on first page; usually previous & continue buttons. on last page, there's submit instead of continue
    - I have "Continue" reset the scroll to the top of the page but not "Previous." **any thoughts on that?**
- **About Submission**
    - @leonna26 what should happen if I try submitting **when all the q's aren't answered?** like, what should the button look like if it's disabled, and if there should be an alert.
    - I think all q's have to be answered to hit 100% & allow submission, but should that be more flexible (for instance, a CheckBox q with one option, "mark this if you have insurance" would force you to have an answer)? should we even block submission at all based on the % filled?

- **Question Types**
    - Is the CheckBox type a question with just 1 box to check? That's what the code currently presents it as & not a multiselect from multiple answers (all example form q's seem to just have 1)
    - ListBox type seems to be multi-select but I can't find an example to check it on.

- **pdfApplication**: @crchong1 if it's a pdfApplication do I just get rid of multiple pages completely?

- update on merge conflict: maybe I just accidentally replaced uuid() with index? lol
![appform](https://user-images.githubusercontent.com/21111373/100568006-e518f280-3297-11eb-9500-33adbdae7040.gif)
