### PR TITLE
Find orgs small fix

### DIFF
--- a/src/components/AccountSecurity/LoginPage.tsx
+++ b/src/components/AccountSecurity/LoginPage.tsx
@@ -365,7 +365,7 @@ class LoginPage extends Component<Props, State> {
                 </div>
                 <div className="row">
                   <div className="col-10 pl-0">
-                    <Link to="/find-organization">
+                    <Link to="/find-organizations">
                       <button type="button" className="btn btn-outline-primary w-100 ">Find Organizations</button>
                     </Link>
                   </div>

--- a/src/components/OrgFinder/FindOrganization.tsx
+++ b/src/components/OrgFinder/FindOrganization.tsx
@@ -187,6 +187,9 @@ class FindOrganization extends Component<Props, State> {
             alert,
           } = this.props;
           alert.show('Invalid zip code');
+          this.setState({
+            searchLoading: false,
+          });
         }
       });
   }


### PR DESCRIPTION
1) Fixed a bug so the link on the login page actually leads to the Find Organizations page. 
2) Updated the submit button on the Find Organizations page to stop showing the loading circle on error.