### PR TITLE
search bar component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,8 @@ import PersonSignupFlow from './components/SignUp/PersonSignupFlow';
 import ClientProfilePage from './components/ClientProfilePage';
 import AutoLogout from './components/AccountSecurity/AutoLogout';
 
+import SearchBarTest from './components/Base/SearchBarTest';
+
 window.onload = () => {
   ReactGA.initialize('UA-176859431-1');
   ReactGA.pageview(window.location.pathname + window.location.search);
@@ -145,6 +147,10 @@ class App extends React.Component<{}, State, {}> {
                   }
                   return <Home />;
                 }}
+              />
+              <Route
+                path="/search-test"
+                render={() => (<SearchBarTest />)}
               />
               <Route
                 path="/find-organizations"

--- a/src/components/Base/SearchBar.tsx
+++ b/src/components/Base/SearchBar.tsx
@@ -1,0 +1,60 @@
+import React, { useState, useEffect } from 'react';
+import FormControl from 'react-bootstrap/FormControl';
+import InputGroup from 'react-bootstrap/InputGroup';
+import searchIcon from '../../static/images/search.svg';
+
+interface Props {
+  searchHeight?: string,
+  searchWidth?: string,
+  searchOnClick: (input: string) => void,
+  searchLoading: boolean,
+}
+
+interface DefaultProps {
+  searchHeight?: string,
+  searchWidth?: string,
+}
+
+function SearchBar(props: Props): React.ReactElement {
+  const [searchInput, setSearchInput] = useState('');
+  const {
+    searchHeight,
+    searchWidth,
+    searchOnClick,
+    searchLoading,
+  } = props;
+  return (
+    <InputGroup style={{ width: searchWidth }}>
+      <FormControl
+        style={{ height: searchHeight }}
+        placeholder="Search"
+        aria-label="Search"
+        aria-describedby="basic-addon1"
+        onChange={(e) => setSearchInput(e.target.value)}
+      />
+      <InputGroup.Append id="basic-addon1">
+        <button
+          className="btn border rounded-right d-flex justify-content-center"
+          type="submit"
+          style={{
+            height: searchHeight,
+          }}
+          onClick={() => searchOnClick(searchInput)}
+        >
+          { searchLoading
+            ? <div className="ld ld-ring ld-spin" />
+            : <img src={searchIcon} alt="search" />}
+        </button>
+      </InputGroup.Append>
+    </InputGroup>
+  );
+}
+
+const defaultProps: DefaultProps = {
+  searchHeight: '36px',
+  searchWidth: '413px',
+};
+
+SearchBar.defaultProps = defaultProps;
+
+export default SearchBar;

--- a/src/components/Base/SearchBarTest.tsx
+++ b/src/components/Base/SearchBarTest.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import SearchBar from './SearchBar';
+import getServerURL from '../../serverOverride';
+
+interface Props {
+}
+
+interface State {
+  searchLoading: boolean,
+}
+
+// example use of search bar
+class SearchBarTest extends React.Component<Props, State, {}> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      searchLoading: false,
+    };
+    this.searchOnClick = this.searchOnClick.bind(this);
+  }
+
+  searchOnClick(input: string) {
+    this.setState({
+      searchLoading: true,
+    });
+    fetch(`${getServerURL()}/get-all-orgs `, {
+      method: 'POST',
+      credentials: 'include',
+      body: JSON.stringify({
+        userTypes: [],
+        organizations: [],
+      }),
+    }).then((response) => response.json())
+      .then((responseJSON) => {
+        const {
+          organizations,
+        } = JSON.parse(responseJSON);
+        this.setState({
+          searchLoading: false,
+        });
+      });
+  }
+
+  render() {
+    const {
+      searchLoading,
+    } = this.state;
+    return (
+      <div className="container p-5">
+        <SearchBar searchOnClick={this.searchOnClick} searchLoading={searchLoading} />
+      </div>
+    );
+  }
+}
+
+export default SearchBarTest;


### PR DESCRIPTION
I implemented @chels20's search bar design with some modifications.

Here are the props:
```
interface Props {
  searchHeight?: string,
  searchWidth?: string,
  searchOnClick: (input: string) => void,
  searchLoading: boolean,
}
```
`searchHeight` and `searchWidth` are optional -- their default values are taken from Chelsea's design.  
`searchOnClick` is the function that clicking the search button should call. The search query/input is passed into the function. 
`searchLoading` represents whether or not (boolean) to show a spinner in place of the magnifying glass icon.  

A screenshot of the search bar:
![image](https://user-images.githubusercontent.com/25329899/106210372-acf93780-6194-11eb-9855-060b356ef760.png)


Search bar when `searchLoading` prop is true:
![image](https://user-images.githubusercontent.com/25329899/106210331-97840d80-6194-11eb-8104-bb360df239a0.png)

Possible TODO: automatically activate the search button when you click enter (it doesn't do that right now).