### PR TITLE
bug fix for wrong credentials detected by back end

### DIFF
--- a/src/components/LandingPages/WorkerLanding.tsx
+++ b/src/components/LandingPages/WorkerLanding.tsx
@@ -156,10 +156,14 @@ class WorkerLanding extends Component<Props, State> {
     const {
       searchName,
     } = this.state;
+    const {
+      role,
+    } = this.props;
     fetch(`${getServerURL()}/get-organization-members`, {
       method: 'POST',
       credentials: 'include',
       body: JSON.stringify({
+        role,
         listType: 'clients',
         name: searchName,
       }),


### PR DESCRIPTION
this is a 2 part pull request. instead of back end getting User Type from ctx session attribute, I changed it to get the role from the fetch body. It was detecting the wrong role when moving between 'client actions' pages and workers landing page. Back end part is linked [here](https://github.com/keepid/keepid_server/tree/bug-fix-wrong-credentials-worker-landing)