### PR TITLE
chore(github): add pull request and issue report templates

### DIFF
--- a/.github/ISSUE_TEMPLATES/BUG_REPORT_ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATES/BUG_REPORT_ISSUE_TEMPLATE.md
@@ -1,0 +1,27 @@
+---
+name: Bug Report
+about: Report an issue with the keep.id website
+title: ''
+labels: Bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATES/NEW_FEATURE_ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATES/NEW_FEATURE_ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+---
+name: New Feature
+about: Create an issue detailing a feature to add to the Keep.id website
+title: ''
+labels: Feature
+assignees: ''
+
+---
+
+**Describe the feature**
+A description of the new feature.
+
+**User Stories**
+Applicable user stories for the feature. (i.e. As a *client/admin/worker*, I want to *do a particular thing* so that I can *achieve some outcome*.) 
+
+**Link to Figma design**
+Add links to the Figma designs associated with this feature, if applicable

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+## Link to Issue
+
+## Description of changes
+
+## Screenshot(s) or GIF(s) of changes

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@
 .env.production.local
 
 .eslintcache
-.github
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
PR and Issue templates help ensure consistency and information completeness. This PR adds:

- A PR template used when opening new PRs
- An issue template for reporting a bug
- An issue template for creating a new feature

To properly hook these up, something with permissions will need to update the repository settings. See: https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository and https://docs.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository