### PR TITLE
feat(components): add input components

### DIFF
--- a/src/components/BaseComponents/Inputs/BaseInputFixture.tsx
+++ b/src/components/BaseComponents/Inputs/BaseInputFixture.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Form } from 'react-bootstrap';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { useValue } from 'react-cosmos/fixture';
+
+interface BaseInputFixtureProps {
+  fixture: (props: any) => JSX.Element,
+  type: string,
+  otherProps?: object | undefined
+}
+
+const BaseInputFixture = ({ fixture: Fixture, type, otherProps }: BaseInputFixtureProps) => {
+  const [name] = useValue<string>('name', { defaultValue: `${type}-input-name` });
+  const [label] = useValue<string>('label', { defaultValue: `${type}Input Label` });
+  const [description] = useValue<string>('description', { defaultValue: `${type} input description` });
+  const [placeholder] = useValue<string>('placeholder', { defaultValue: `${type} input placeholder` });
+  const [required] = useValue<boolean>('required', { defaultValue: true });
+  const [value, setValue] = useState(undefined);
+  const logAndSetValue = (value) => { console.log(value); setValue(value); };
+  return (
+    <Form
+      style={{
+        border: '1px solid lightgray', margin: '25px', padding: '25px',
+      }}
+      name="TextInput-test-form"
+      onSubmit={(e) => { e.preventDefault(); console.log(e); }}
+    >
+      <Fixture {...{
+        name,
+        label,
+        description,
+        placeholder,
+        value,
+        onChange: logAndSetValue,
+        required,
+        ...(otherProps || {}),
+      }}
+      />
+    </Form>
+  );
+};
+
+BaseInputFixture.defaultProps = { otherProps: {} };
+
+export default BaseInputFixture;

--- a/src/components/BaseComponents/Inputs/BaseInputProps.ts
+++ b/src/components/BaseComponents/Inputs/BaseInputProps.ts
@@ -1,0 +1,26 @@
+/* eslint-disable semi */
+import { InputWrapperProps } from './InputWrapper';
+
+export default interface InputProps<T> extends Omit<InputWrapperProps, 'children'> {
+  /**
+   * Optional className to apply to input component
+   */
+  className?: string | undefined;
+  /**
+   * Default value of the input
+   */
+  defaultValue?: T | undefined;
+  /**
+   * Optional callback invoked upon value change
+   * @param value - The updated value of the input component
+   */
+  onChange?: (value: T) => void;
+  /**
+   * Optional placeholder value passed to the input
+   */
+  placeholder?: string | undefined;
+  /**
+   * The optional controlled value to pass to the input component
+   */
+  value?: T | undefined;
+}

--- a/src/components/BaseComponents/Inputs/DateInput.fixture.tsx
+++ b/src/components/BaseComponents/Inputs/DateInput.fixture.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { useValue } from 'react-cosmos/fixture';
+
+import { DateInput } from '.';
+import BaseInputFixture from './BaseInputFixture';
+
+const DateInputFixture = () => {
+  const [showTimeSelect] = useValue('showTimeSelect', { defaultValue: false });
+  return <BaseInputFixture fixture={DateInput} type="Date" otherProps={{ showTimeSelect }} />;
+};
+
+export default DateInputFixture;

--- a/src/components/BaseComponents/Inputs/DateInput.test.tsx
+++ b/src/components/BaseComponents/Inputs/DateInput.test.tsx
@@ -1,0 +1,106 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@testing-library/jest-dom/extend-expect';
+
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { DateInput } from '.';
+
+describe('DateInput', () => {
+  const label = 'Test Input Label';
+  const name = 'test-input';
+
+  test('should render the label and apply the name attribute', () => {
+    const { getByLabelText, getByText } = render(<DateInput label={label} name={name} />);
+
+    expect(getByText(label)).toBeInTheDocument();
+    expect(getByText(label).getAttribute('for')).toEqual(name);
+
+    expect(getByLabelText(label)).toBeInTheDocument();
+    expect(getByLabelText(label).getAttribute('name')).toEqual(name);
+  });
+
+  test('should show date picker on click and call onChange with selected value', async () => {
+    const onChange = jest.fn();
+    const value = new Date();
+    const { getByLabelText, getByText, rerender } = render(
+      <DateInput label={label} name={name} onChange={onChange} value={value} />,
+    );
+
+    fireEvent.click(getByLabelText(label));
+
+    await waitFor(() => {
+      Array(28).forEach((_, idx) => expect(getByText(idx)).toBeInTheDocument());
+    });
+
+    fireEvent.click(getByText(10));
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    const args = onChange.mock.calls[0];
+    expect(args[0]).toBeInstanceOf(Date);
+    expect(args[0].getFullYear()).toEqual(new Date().getFullYear());
+    expect(args[0].getMonth()).toEqual(new Date().getMonth());
+    expect(args[0].getDate()).toEqual(10);
+
+    value.setDate(args[0].getDate());
+    rerender(<DateInput label={label} name={name} onChange={onChange} value={value} />);
+    const month = new Date().getUTCMonth() + 1;
+
+    await waitFor(() => {
+      expect(getByLabelText(label).getAttribute('value')).toEqual(
+        [(month < 10 ? '0' : '') + month, 10, new Date().getFullYear()].join('/'),
+      );
+    });
+  });
+
+  test('should render time selection on click and call onChange with selected value', async () => {
+    const onChange = jest.fn();
+    const { getByLabelText, getByText } = render(
+      <DateInput label={label} name={name} onChange={onChange} showTimeSelect />,
+    );
+
+    fireEvent.click(getByLabelText(label));
+
+    await waitFor(() => {
+      expect(getByText('Time')).toBeInTheDocument();
+    });
+
+    fireEvent.click(getByText('10:30 AM'));
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const expectedDate = new Date();
+      expectedDate.setHours(10);
+      expectedDate.setMinutes(30);
+      const args = onChange.mock.calls[0];
+      expect(args[0]).toBeInstanceOf(Date);
+      expect(args[0].getFullYear()).toEqual(expectedDate.getFullYear());
+      expect(args[0].getMonth()).toEqual(expectedDate.getMonth());
+      expect(args[0].getDate()).toEqual(expectedDate.getDate());
+      expect(args[0].getUTCHours()).toEqual(expectedDate.getUTCHours());
+      expect(args[0].getUTCMinutes()).toEqual(expectedDate.getUTCMinutes());
+    });
+  });
+
+  test('should render the placeholder', () => {
+    const placeholder = 'the placeholder';
+    const { getByLabelText } = render(<DateInput label={label} name={name} placeholder={placeholder} />);
+
+    expect(getByLabelText(label)).toBeInTheDocument();
+    expect(getByLabelText(label).getAttribute('placeholder')).toEqual(placeholder);
+  });
+
+  test('should render the default value', () => {
+    const defaultValue = '01/01/2015';
+    const { getByLabelText } = render(
+      <DateInput label={label} name={name} defaultValue={new Date(2015, 0, 1, 12)} />,
+    );
+
+    const input = getByLabelText(label);
+    expect(input).toBeInTheDocument();
+    expect(input?.getAttribute('value')).toEqual(defaultValue);
+  });
+});

--- a/src/components/BaseComponents/Inputs/DateInput.tsx
+++ b/src/components/BaseComponents/Inputs/DateInput.tsx
@@ -1,0 +1,44 @@
+import 'react-datepicker/dist/react-datepicker.css';
+
+import classNames from 'classnames';
+import React from 'react';
+import DatePicker from 'react-datepicker';
+
+import InputProps from './BaseInputProps';
+import InputWrapper from './InputWrapper';
+
+interface DateInputProps extends InputProps<Date | undefined> {
+  showTimeSelect?: boolean | undefined;
+}
+
+const DateInput = ({
+  className: classNameProp,
+  defaultValue,
+  name,
+  label,
+  onChange,
+  placeholder,
+  showTimeSelect,
+  value,
+  ...rest
+}: DateInputProps) => {
+  const className = classNames('form-control', 'form-purple', classNameProp);
+
+  return (
+    <InputWrapper label={label} name={name} {...rest}>
+      <DatePicker
+        className={className}
+        id={name}
+        name={name}
+        onChange={(d) => onChange && onChange(d)}
+        placeholderText={placeholder}
+        selected={value || defaultValue}
+        showTimeSelect={showTimeSelect}
+      />
+    </InputWrapper>
+  );
+};
+
+DateInput.defaultProps = { showTimeSelect: false };
+
+export default DateInput;

--- a/src/components/BaseComponents/Inputs/Form.fixture.tsx
+++ b/src/components/BaseComponents/Inputs/Form.fixture.tsx
@@ -1,0 +1,60 @@
+/* eslint-disable radix */
+import React, { useState } from 'react';
+import { Button, Form } from 'react-bootstrap';
+
+import { DateInput, SelectInput, TextInput } from './index';
+
+const options = new Array(20).fill('').map((i, idx) => ({ label: `Option ${idx}`, value: `option-val-${idx}` }));
+
+const FormFixture = () => {
+  const [dateValue, setDateValue] = useState<Date | undefined>();
+  const [textValue, setTextValue] = useState('');
+  const [selectValue, setSelectValue] = useState('');
+  return (
+    <Form
+      style={{
+        border: '1px solid lightgray',
+        margin: '25px',
+        padding: '25px',
+      }}
+      name="TextInput-test-form"
+      onSubmit={(e) => {
+        e.preventDefault();
+        console.log(e, { textValue, dateValue, selectValue });
+      }}
+    >
+      <TextInput
+        label="Text Input"
+        name="text-input"
+        required
+        description="Description for the input"
+        value={textValue}
+        onChange={setTextValue}
+      />
+      <SelectInput
+        options={options}
+        label="Select Input"
+        name="select-input"
+        description="Description for the input"
+        value={selectValue}
+        onChange={setSelectValue}
+      />
+
+      <DateInput
+        label="Date Input"
+        name="date-input"
+        description="Description for the input"
+        value={dateValue}
+        onChange={setDateValue}
+      />
+
+      <Form.Group>
+        <Button variant="primary" type="submit">
+          Submit
+        </Button>
+      </Form.Group>
+    </Form>
+  );
+};
+
+export default FormFixture;

--- a/src/components/BaseComponents/Inputs/InputWrapper.tsx
+++ b/src/components/BaseComponents/Inputs/InputWrapper.tsx
@@ -1,0 +1,50 @@
+import classNames from 'classnames';
+import React from 'react';
+import { Form } from 'react-bootstrap';
+
+export interface InputWrapperProps {
+  /**
+   * Optional description text to display under the label
+   */
+  description?: string | undefined;
+  /**
+   * Label to attach to the input
+   */
+  label: string;
+  /**
+   * HTML name attribute to attach to the input
+   */
+  name: string;
+  /**
+   * Optional boolean indicating whether the input is required
+   */
+  required?: boolean | undefined;
+  /**
+   * Optional className to apply to the label component
+   */
+  labelClassName?: string | undefined;
+  /**
+   * Children to render within the input wrapper
+   */
+  children: JSX.Element | JSX.Element[];
+}
+
+const InputWrapper = ({
+  children,
+  description,
+  label,
+  name,
+  required,
+  labelClassName,
+}: InputWrapperProps) => {
+  const className = classNames('input-label', labelClassName, { required });
+  return (
+    <Form.Group>
+      <Form.Label className={className} htmlFor={name}>{label}</Form.Label>
+      {children}
+      {description ? <Form.Text>{description}</Form.Text> : null}
+    </Form.Group>
+  );
+};
+
+export default InputWrapper;

--- a/src/components/BaseComponents/Inputs/SelectInput.fixture.tsx
+++ b/src/components/BaseComponents/Inputs/SelectInput.fixture.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { SelectInput } from '.';
+import BaseInputFixture from './BaseInputFixture';
+
+const options = new Array(20).fill('').map((i, idx) => ({ label: `Option ${idx}`, value: `option-val-${idx}` }));
+
+const SelectInputFixture = () => <BaseInputFixture fixture={SelectInput} otherProps={{ options }} type="Select" />;
+export default SelectInputFixture;

--- a/src/components/BaseComponents/Inputs/SelectInput.test.tsx
+++ b/src/components/BaseComponents/Inputs/SelectInput.test.tsx
@@ -1,0 +1,75 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@testing-library/jest-dom/extend-expect';
+
+import {
+  fireEvent, queries, queryHelpers, render, waitFor,
+} from '@testing-library/react';
+import React from 'react';
+
+import { SelectInput } from '.';
+
+const queryByNameAttributeQuery = (container, id, options) => queryHelpers.queryByAttribute('name', container, id, options);
+
+describe('SelectInput', () => {
+  const label = 'Test Input Label';
+  const name = 'test-input';
+  const options = new Array(20).fill('').map((i, idx) => ({ label: `Option ${idx}`, value: `option-val-${idx}` }));
+
+  test('should render the label and apply the name attribute', () => {
+    const { getByLabelText, getByText, queryByNameAttribute } = render(
+      <SelectInput label={label} name={name} options={options} />,
+      { queries: { ...queries, queryByNameAttribute: queryByNameAttributeQuery } },
+    );
+
+    expect(getByText(label)).toBeInTheDocument();
+    expect(getByText(label).getAttribute('for')).toEqual(name);
+
+    expect(getByLabelText(label)).toBeInTheDocument();
+    expect(queryByNameAttribute(name)).toBeInTheDocument();
+  });
+
+  test('should render options in list on click and call onChange with selected value', async () => {
+    const onChange = jest.fn();
+    const { getByLabelText, getByText } = render(
+      <SelectInput label={label} name={name} options={options} onChange={onChange} />,
+      { queries: { ...queries, queryByNameAttribute: queryByNameAttributeQuery } },
+    );
+
+    // for some reason clicking doesn't work in tests
+    fireEvent.keyDown(getByLabelText(label), { keyCode: 40 });
+
+    await waitFor(() => {
+      options.forEach((o) => expect(getByText(o.label)).toBeInTheDocument());
+    });
+
+    fireEvent.click(getByText(options[4].label));
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(options[4]);
+    });
+  });
+
+  test('should render the placeholder', () => {
+    const placeholder = 'the placeholder';
+    const { getByLabelText, getByText } = render(
+      <SelectInput label={label} name={name} options={options} placeholder={placeholder} />,
+      { queries: { ...queries, queryByNameAttribute: queryByNameAttributeQuery } },
+    );
+
+    expect(getByLabelText(label)).toBeInTheDocument();
+    expect(getByText(placeholder)).toBeInTheDocument();
+  });
+
+  test('should render the default value', () => {
+    const defaultValue = options[3].value;
+    const { queryByNameAttribute } = render(
+      <SelectInput label={label} name={name} options={options} defaultValue={defaultValue} />,
+      { queries: { ...queries, queryByNameAttribute: queryByNameAttributeQuery } },
+    );
+
+    const input = queryByNameAttribute(name);
+    expect(input).toBeInTheDocument();
+    expect(input?.getAttribute('value')).toEqual(options[3].value);
+  });
+});

--- a/src/components/BaseComponents/Inputs/SelectInput.tsx
+++ b/src/components/BaseComponents/Inputs/SelectInput.tsx
@@ -1,0 +1,47 @@
+import classNames from 'classnames';
+import React from 'react';
+import Select from 'react-select';
+
+import InputProps from './BaseInputProps';
+import InputWrapper from './InputWrapper';
+
+interface SelectOption {
+  label: string;
+  value: string;
+}
+
+export interface SelectInputProps extends InputProps<string> {
+  options: SelectOption[];
+}
+
+const SelectInput = ({
+  className: classNameProp,
+  defaultValue,
+  name,
+  onChange,
+  options,
+  placeholder,
+  value,
+  ...rest
+}: SelectInputProps) => {
+  const className = classNames('form-select', 'form-purple', classNameProp);
+  return (
+    <InputWrapper name={name} {...rest}>
+      <Select
+        defaultValue={options.find((i) => i.value === defaultValue)}
+        className={className}
+        inputId={name}
+        isClearable={!rest.required}
+        name={name}
+        onChange={(option) => onChange && onChange(option)}
+        options={options}
+        placeholder={placeholder}
+        value={options.find((i) => i.value === value)}
+      />
+    </InputWrapper>
+  );
+};
+
+SelectInput.defaultProps = { options: [] };
+
+export default SelectInput;

--- a/src/components/BaseComponents/Inputs/TextInput.fixture.tsx
+++ b/src/components/BaseComponents/Inputs/TextInput.fixture.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { useSelect } from 'react-cosmos/fixture';
+
+import { TextInput } from '.';
+import BaseInputFixture from './BaseInputFixture';
+import { TextInputType } from './TextInput';
+
+const TextInputFixture = () => {
+  const [type] = useSelect('type', { options: Object.values(TextInputType), defaultValue: TextInputType.TEXT });
+  return <BaseInputFixture fixture={TextInput} type="Text" otherProps={{ type }} />;
+};
+
+export default TextInputFixture;

--- a/src/components/BaseComponents/Inputs/TextInput.test.tsx
+++ b/src/components/BaseComponents/Inputs/TextInput.test.tsx
@@ -1,0 +1,81 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@testing-library/jest-dom/extend-expect';
+
+import {
+  fireEvent, render, waitFor,
+} from '@testing-library/react';
+import React from 'react';
+
+import { TextInput } from '.';
+
+describe('TextInput', () => {
+  const label = 'Test Input Label';
+  const name = 'test-input';
+
+  beforeEach(() => {
+    // @ts-ignore
+    global.window.matchMedia = jest.fn(() => ({
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    }));
+  });
+  test('should render the label and apply the name attribute', () => {
+    const { getByLabelText, getByText } = render(<TextInput label={label} name={name} />);
+
+    expect(getByText(label)).toBeInTheDocument();
+    expect(getByText(label).getAttribute('for')).toEqual(name);
+
+    expect(getByLabelText(label)).toBeInTheDocument();
+    expect(getByLabelText(label).getAttribute('name')).toEqual(name);
+  });
+
+  test('should render the placeholder text', () => {
+    const placeholder = 'the placeholder';
+    const { getByLabelText } = render(<TextInput label={label} name={name} placeholder={placeholder} />);
+
+    expect(getByLabelText(label)).toBeInTheDocument();
+    expect(getByLabelText(label).getAttribute('placeholder')).toEqual(placeholder);
+  });
+
+  test('should render the required indicator', () => {
+    const { getByLabelText } = render(<TextInput label={label} name={name} required />);
+
+    expect(getByLabelText(label)).toBeInTheDocument();
+    // TODO assert presence of required indicator (???)
+  });
+
+  test('should call onChange with the updated value', async () => {
+    const onChange = jest.fn();
+    const newValue = 'New Value';
+    const { getByLabelText } = render(<TextInput label={label} name={name} onChange={onChange} />);
+
+    expect(getByLabelText(label)).toBeInTheDocument();
+
+    fireEvent.input(getByLabelText(label), { target: { value: newValue } });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toBeCalledWith(newValue);
+    });
+  });
+
+  test('should use the default value', async () => {
+    const defaultValue = 'defaultValue';
+    const { getByLabelText } = render(<TextInput label={label} name={name} defaultValue={defaultValue} />);
+
+    expect(getByLabelText(label)).toBeInTheDocument();
+    expect(getByLabelText(label).getAttribute('value')).toEqual(defaultValue);
+  });
+
+  test('should use controlled value', async () => {
+    const controlledValue = 'controlled value';
+    const { getByLabelText } = render(<><TextInput label={label} name={name} value={controlledValue} /></>);
+
+    expect(getByLabelText(label)).toBeInTheDocument();
+    fireEvent.input(getByLabelText(label), { target: { value: 'New Value' } });
+
+    await waitFor(() => {
+      expect(getByLabelText(label).getAttribute('value')).toEqual(controlledValue);
+    });
+  });
+});

--- a/src/components/BaseComponents/Inputs/TextInput.tsx
+++ b/src/components/BaseComponents/Inputs/TextInput.tsx
@@ -1,0 +1,48 @@
+import classNames from 'classnames';
+import React from 'react';
+
+import InputProps from './BaseInputProps';
+import InputWrapper from './InputWrapper';
+
+export enum TextInputType {
+  EMAIL = 'email',
+  PASSWORD = 'password',
+  TEXT = 'text'
+}
+
+export interface TextInputProps extends InputProps<string> {
+  type?: TextInputType
+}
+
+const TextInput = ({
+  className: classNameProp,
+  defaultValue,
+  label,
+  name,
+  onChange,
+  placeholder,
+  type,
+  value,
+  ...rest
+}: TextInputProps) => {
+  const className = classNames('form-control', 'form-purple', classNameProp);
+  return (
+    <InputWrapper label={label} name={name} {...rest}>
+      <input
+        className={className}
+        defaultValue={defaultValue}
+        id={name}
+        name={name}
+        onChange={(e) => onChange && onChange(e.target.value)}
+        placeholder={placeholder}
+        required={rest.required}
+        type={type}
+        value={value}
+      />
+    </InputWrapper>
+  );
+};
+
+TextInput.defaultProps = { type: TextInputType.TEXT };
+
+export default TextInput;

--- a/src/components/BaseComponents/Inputs/index.tsx
+++ b/src/components/BaseComponents/Inputs/index.tsx
@@ -1,0 +1,3 @@
+export { default as TextInput } from './TextInput';
+export { default as DateInput } from './DateInput';
+export { default as SelectInput } from './SelectInput';

--- a/src/static/styles/App.scss
+++ b/src/static/styles/App.scss
@@ -1,6 +1,8 @@
 @import "../../../node_modules/bootstrap/scss/bootstrap";
 @import "./ldbtn.scss";
 @import "./loading.scss";
+@import "./Inputs";
+
 // COLOR SYTEM
 $primary-theme: #7B81FF;
 $primary-theme-light: #e8e9ff;
@@ -359,7 +361,7 @@ thead {
 
 .footer-brand {
 	filter: invert(45%) sepia(50%) saturate(1499%) hue-rotate(213deg) brightness(104%) contrast(101%);
-	// outline-color: 
+	// outline-color:
 }
 
 .footer-brand-logo {

--- a/src/static/styles/Inputs.scss
+++ b/src/static/styles/Inputs.scss
@@ -1,0 +1,9 @@
+.input-label {
+	font-size: 1rem;
+	font-weight: 600;
+}
+
+.input-label.required:after {
+	content: ' *';
+	color: red;
+}


### PR DESCRIPTION
  * add TextInput, SelectInput, and DateInput
  * add testing
  * add Form fixture

## Description of changes
- Add new shared Input components for Text, Date, and Select input types. The styling isn't all the way there yet, but these inputs will be initially used for the internal production dashboard so it's not a huge deal. Ultimately, it would be great to use these Inputs everywhere in the app.

## Screenshot(s) or GIF(s) of changes
![image](https://user-images.githubusercontent.com/11894114/117074394-dd52f380-acf8-11eb-9dfe-114c36525750.png)
