### PR TITLE
fix(my-documents): default sort by upload date

### DIFF
--- a/src/components/BaseComponents/Table/Table.tsx
+++ b/src/components/BaseComponents/Table/Table.tsx
@@ -18,13 +18,7 @@ import TModal from './TModal';
 // custom results display for table
 const customTotal = (from, to, size) => (
   <span className="react-bootstrap-table-pagination-total">
-    Showing
-    {from}
--
-{to}
-    of
-    {size}
-    Results
+    {`Showing ${from}-${to} of ${size} Results`}
   </span>
 );
 
@@ -224,6 +218,8 @@ interface TableProps extends NoDataIndicationProps {
   onDelete?: (id: any) => void;
   // Method called upon Row modification save
   onEditSave?: (row: any) => void;
+  // Default sort settings
+  defaultSorted?: { dataField: string, order: 'asc' | 'desc' }[]
 }
 
 /**

--- a/src/components/Documents/MyDocuments.tsx
+++ b/src/components/Documents/MyDocuments.tsx
@@ -357,6 +357,7 @@ class MyDocuments extends Component<Props, State> {
                           data={documentData}
                           columns={this.tableCols}
                           emptyInfo={{ description: 'No documents found' }}
+                          defaultSorted={[{ dataField: 'uploadDate', order: 'asc' }]}
                         />
                       </div>
                     )


### PR DESCRIPTION
## Link to Issue
https://github.com/keepid/keepid_client/issues/328

## Description of changes
By default, sort My Documents by upload date, with most recent document first

## Screenshot(s) or GIF(s) of changes
![image](https://user-images.githubusercontent.com/11894114/149050964-16e3f4fd-71bf-4ec0-b507-ea072e92df47.png)
