### PR TITLE
chore(my-account): hide login history location

### DIFF
--- a/src/components/AccountSettings/MyAccount.tsx
+++ b/src/components/AccountSettings/MyAccount.tsx
@@ -74,11 +74,6 @@ const loginHistoryCols = [{
   dataField: 'device',
   text: 'Device',
   sort: true,
-},
-{
-  dataField: 'location',
-  text: 'Location',
-  sort: true,
 }];
 
 export class MyAccount extends Component<Props, State, {}> {


### PR DESCRIPTION
## Link to Issue
Closes https://github.com/keepid/keepid_client/issues/327

## Description of changes
Remove the Location column from the `Login History` section from MyAccount

![image](https://user-images.githubusercontent.com/11894114/150046570-f9ef59b7-f37a-44fb-9dd6-2b2f5b9656cd.png)

