### PR TITLE
Shows useful guidance when users without email try to reset their password

### DIFF
--- a/src/components/UserAuthentication/ForgotPassword.tsx
+++ b/src/components/UserAuthentication/ForgotPassword.tsx
@@ -59,6 +59,12 @@ class ForgotPassword extends Component<Props, State> {
           } else if (status === 'USER_NOT_FOUND') {
             this.props.alert.show('Incorrect Username');
             this.setState({ buttonState: '' });
+          } else if (status == 'NOT_VALID_EMAIL') {
+            this.props.alert.show(
+              'There is no valid email address associated with this username. '
+              + 'Please contact your nonprofit to get your password recovery code.',
+            );
+            this.setState({ buttonState: '' });
           } else {
             this.props.alert.show('Server Failure: Please Try Again');
             this.setState({ buttonState: '' });


### PR DESCRIPTION
## Fixes #399 

## Description of changes
Displays a more useful error message

## Screenshot(s) or GIF(s) of changes
![image](https://user-images.githubusercontent.com/26119970/179040267-20399708-db1b-428e-9263-0f3ced5dc1fd.png)
