### PR TITLE
Remove Uploader Field from Documents View, Add Basic File Importer to…

### DIFF
--- a/src/components/Applications/ApplicationForm.tsx
+++ b/src/components/Applications/ApplicationForm.tsx
@@ -4,6 +4,7 @@ import React, { Component } from 'react';
 import { withAlert } from 'react-alert';
 import { Button } from 'react-bootstrap';
 import DatePicker from 'react-datepicker';
+import Dropzone from 'react-dropzone-uploader';
 import { Helmet } from 'react-helmet';
 import { Link, Redirect } from 'react-router-dom';
 import uuid from 'react-uuid';
@@ -12,6 +13,7 @@ import SignaturePad from '../../lib/SignaturePad';
 import getServerURL from '../../serverOverride';
 import PDFType from '../../static/PDFType';
 import DocumentViewer from '../Documents/DocumentViewer';
+import DropzoneUploader from '../Documents/DropzoneUploader';
 
 interface Field {
   fieldID: string; // Unique identifier id from frontend
@@ -42,6 +44,7 @@ interface State {
   currentPage: number;
   numPages: number;
   formError: boolean;
+  importApplicationDataFile: File | undefined;
 }
 
 const MAX_Q_PER_PAGE = 10;
@@ -62,6 +65,7 @@ class ApplicationForm extends Component<Props, State> {
       currentPage: 1,
       numPages: 1,
       formError: false,
+      importApplicationDataFile: undefined,
     };
   }
 
@@ -124,6 +128,11 @@ class ApplicationForm extends Component<Props, State> {
       () => window.scrollTo(0, 0),
     );
   };
+
+  handleImportApplicationData = (fileObject) => {
+    this.setState({ importApplicationDataFile: fileObject.file });
+    // Refresh Application Load
+  }
 
   handleChangeFormValueTextField = (event: any) => {
     const { formAnswers } = this.state;
@@ -370,10 +379,10 @@ class ApplicationForm extends Component<Props, State> {
     const mm = date.getMonth() + 1; // getMonth() is zero-based
     const dd = date.getDate();
     const dateString = [
-      date.getFullYear(),
       (mm > 9 ? '' : '0') + mm,
       (dd > 9 ? '' : '0') + dd,
-    ].join('-');
+      date.getFullYear(),
+    ].join('/');
     return dateString;
   };
 
@@ -539,6 +548,15 @@ class ApplicationForm extends Component<Props, State> {
             </div>
           </div>
           <div className="container border px-5 col-lg-10 col-md-10 col-sm-12">
+            {currentPage == 1 ? (
+<Dropzone
+  onSubmit={this.handleImportApplicationData}
+  maxFiles={1}
+  accept="application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+  inputContent="Import Data for Application"
+  submitButtonContent="Import"
+/>
+            ) : <></>}
             <form onSubmit={this.onSubmitFormAnswers}>
               {fields.map((entry, index) => {
                 if (index < qStartNum || index >= qStartNum + MAX_Q_PER_PAGE) return null;

--- a/src/components/Documents/MyDocuments.tsx
+++ b/src/components/Documents/MyDocuments.tsx
@@ -339,11 +339,6 @@ class MyDocuments extends Component<Props, State> {
       },
     },
     {
-      dataField: 'uploader',
-      text: 'Uploader',
-      sort: true,
-    },
-    {
       dataField: 'idCategory',
       text: 'ID Type',
       sort: true,

--- a/src/components/Documents/MyDocuments.tsx
+++ b/src/components/Documents/MyDocuments.tsx
@@ -32,6 +32,7 @@ interface State {
   currentDocumentName: string | undefined;
   currentUploadDate: string | undefined;
   currentUploader: string | undefined;
+  currentUserRole: Role | undefined;
   documentData: any;
 }
 
@@ -81,6 +82,7 @@ class MyDocuments extends Component<Props, State> {
       currentDocumentName: undefined,
       currentUploadDate: undefined,
       currentUploader: undefined,
+      currentUserRole: undefined,
       documentData: [],
     };
     this.getDocumentData = this.getDocumentData.bind(this);
@@ -260,6 +262,8 @@ class MyDocuments extends Component<Props, State> {
 
   getDocumentData() {
     const { userRole } = this.props;
+    this.setState({currentUserRole: userRole});
+
     let pdfType;
     let targetUser;
     if (
@@ -358,7 +362,7 @@ class MyDocuments extends Component<Props, State> {
   }
 
   render() {
-    const { pdfFiles, buttonState } = this.state;
+    const { pdfFiles, buttonState, currentUserRole } = this.state;
 
     const { userRole, username } = this.props;
     const {
@@ -368,13 +372,12 @@ class MyDocuments extends Component<Props, State> {
       currentUploadDate,
       currentUploader,
     } = this.state;
-    console.log(currentDocumentId, currentDocumentName, username);
     return (
       <Switch>
         <Route path="/my-documents/view">
           {currentDocumentId && currentDocumentName ? (
             <ViewDocument
-              userRole={userRole}
+              userRole={currentUserRole}
               documentId={currentDocumentId}
               documentName={currentDocumentName}
               documentDate={currentUploadDate}


### PR DESCRIPTION
Fixing Issues for Face to Face Birth Certificate Clinic Tomorrow

1. Remove the "Uploader" field from MyDocuments table so that we can see all the buttons without they being squished
2. Current Date field now has the year at the end, instead of the beginning
3. Show the CSV Uploader Box for the Applications Feature (start of potential feature for them)

I also fixed that the "View" button didn't work for viewing the completed applications for an admin. The "View" button still works for clients viewing their own documents, but it still fails for an admin trying to view client docs (this has been known before to be failing though)