### PR TITLE
fix autologout and add unit testing

### DIFF
--- a/src/components/UserAuthentication/AutoLogout.tsx
+++ b/src/components/UserAuthentication/AutoLogout.tsx
@@ -72,7 +72,7 @@ function AutoLogout(props: Props): React.ReactElement {
   }, []);
 
   return (
-    <div>
+    <div data-testid="auto-logout">
       <IdleTimer
         key="idleTimerWarn"
         ref={(ref) => {

--- a/src/components/UserAuthentication/IdleTimeOutModal.tsx
+++ b/src/components/UserAuthentication/IdleTimeOutModal.tsx
@@ -10,7 +10,7 @@ interface Props {
 function IdleTimeOutModal(props: Props): React.ReactElement {
   const { showModal, handleClose, handleLogout } = props;
   return (
-    <Modal show={showModal}>
+    <Modal show={showModal} data-testid="warn-modal">
       <Modal.Header>
         <Modal.Title>You have been idle for some time...</Modal.Title>
       </Modal.Header>

--- a/src/tests/components/AutoLogout/AutoLogout.test.tsx
+++ b/src/tests/components/AutoLogout/AutoLogout.test.tsx
@@ -1,8 +1,12 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { act } from 'react-test-renderer';
 
 import AutoLogout from '../../../components/UserAuthentication/AutoLogout';
+
+const timeUntilWarn: number = 1000 * 60 * 50; // 50 minutes
+const timeFromWarnToLogout: number = 1000 * 60 * 10; // 10 minutes
+const timeBeforeConsideredSleep: number = 1000 * 60 * 5; // 5 minutes
 
 jest.useFakeTimers();
 
@@ -10,17 +14,17 @@ describe('AutoLogout', () => {
   afterEach(() => {
     jest.clearAllTimers();
   });
+  // increase timeout to 10 seconds for this test case
+  jest.setTimeout(10000);
 
   it('should not show warn modal with mouse activity', () => {
+    jest.advanceTimersByTime(1000 * 60 * 50); // 50 minutes
     act(() => {
       // simulate mouse activity
       window.dispatchEvent(new MouseEvent('mousemove', { bubbles: true }));
       window.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
       window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
     });
-
-    jest.advanceTimersByTime(1000 * 60 * 50); // 50 minutes
-
     expect(screen.queryByTestId('warn-modal')).toBeNull();
 
     jest.advanceTimersByTime(1000 * 60 * 10); // 10 minutes
@@ -28,18 +32,26 @@ describe('AutoLogout', () => {
     expect(screen.queryByTestId('warn-modal')).toBeNull();
   });
 
-  it('should show warn modal with keyboard activity', () => {
+  it('should not show warn modal with keyboard activity', () => {
+    jest.advanceTimersByTime(1000 * 60 * 50); // 50 minutes
     act(() => {
       // simulate keyboard activity
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
     });
-
-    jest.advanceTimersByTime(1000 * 60 * 50); // 50 minutes
-
     expect(screen.queryByTestId('warn-modal')).toBeNull();
 
     jest.advanceTimersByTime(1000 * 60 * 10); // 10 minutes
 
     expect(screen.queryByTestId('warn-modal')).toBeNull();
+  });
+
+  it('should show warn modal with no activity', async () => {
+    render(<AutoLogout logOut={jest.fn()} setAutoLogout={jest.fn()} />);
+
+    act(() => {
+      jest.advanceTimersByTime(1000 * 60 * 50); // 50 minutes
+    });
+
+    expect(screen.queryByTestId('warn-modal')).not.toBeNull();
   });
 });

--- a/src/tests/components/AutoLogout/AutoLogout.test.tsx
+++ b/src/tests/components/AutoLogout/AutoLogout.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { act } from 'react-test-renderer';
+
+import AutoLogout from '../../../components/UserAuthentication/AutoLogout';
+
+jest.useFakeTimers();
+
+describe('AutoLogout', () => {
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('should not show warn modal with mouse activity', () => {
+    act(() => {
+      // simulate mouse activity
+      window.dispatchEvent(new MouseEvent('mousemove', { bubbles: true }));
+      window.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    });
+
+    jest.advanceTimersByTime(1000 * 60 * 50); // 50 minutes
+
+    expect(screen.queryByTestId('warn-modal')).toBeNull();
+
+    jest.advanceTimersByTime(1000 * 60 * 10); // 10 minutes
+
+    expect(screen.queryByTestId('warn-modal')).toBeNull();
+  });
+
+  it('should show warn modal with keyboard activity', () => {
+    act(() => {
+      // simulate keyboard activity
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+    });
+
+    jest.advanceTimersByTime(1000 * 60 * 50); // 50 minutes
+
+    expect(screen.queryByTestId('warn-modal')).toBeNull();
+
+    jest.advanceTimersByTime(1000 * 60 * 10); // 10 minutes
+
+    expect(screen.queryByTestId('warn-modal')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Link to Issue
1. The previous code is incapable of detecting user behavior (mouse, keyboard) and resetting the timer to avoid auto logout. 
2. The previous code had no unit test.

## Description of changes

- AutoLogout:
  - Reduces the idle time limit from 2 hours to 50 minutes and the time from warning to logout from 1 minute to 10 minutes. 
  - Additionally, the time before the component is considered asleep has been reduced from 15 seconds to 5 seconds.

- Unit testing
  - Simulate mouse and keyboard activity and check that the warning modal is displayed after 50 minutes of inactivity and the user is logged out after 10 minutes. 
  - Check that user activity prevents the warning modal from being displayed.

## Screenshot(s) or GIF(s) of changes
