### PR TITLE
fix autologout and add unit testing

### DIFF
--- a/src/components/UserAuthentication/AutoLogout.tsx
+++ b/src/components/UserAuthentication/AutoLogout.tsx
@@ -86,7 +86,6 @@ function AutoLogout(props: Props): React.ReactElement {
       />
       <IdleTimeOutModal showModal={showModal} handleClose={onClose} handleLogout={handleLogout} />
       <DeviceSleepDetect timeOut={timeBeforeConsideredSleep} handleAutoLogout={handleAutoLogout} />
-      <p>Seconds Idle: {secondsIdle}</p>
     </div>
   );
 }

--- a/src/components/UserAuthentication/AutoLogout.tsx
+++ b/src/components/UserAuthentication/AutoLogout.tsx
@@ -1,24 +1,26 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import IdleTimer from 'react-idle-timer';
 import { useHistory } from 'react-router-dom';
 
 import DeviceSleepDetect from './DeviceSleepDetect';
 import IdleTimeOutModal from './IdleTimeOutModal';
 
-const timeUntilWarn: number = 1000 * 60 * 120; // two hours in milliseconds
-const timeFromWarnToLogout: number = 1000 * 60; // 1 minute in milliseconds
-const timeBeforeConsideredSleep: number = 1000 * 15; // 15 seconds in milliseconds
+const timeUntilWarn: number = 1000 * 10; // 10 minutes
+const timeFromWarnToLogout: number = 1000 * 5; // 5 minutes
+const timeBeforeConsideredSleep: number = 1000 * 60 * 2; // 2 minutes
 
 interface Props {
-    logOut: () => void,
-    setAutoLogout: (boolean) => void,
+  logOut: () => void;
+  setAutoLogout: (boolean) => void;
 }
 
 function AutoLogout(props: Props): React.ReactElement {
   const [showModal, setShowModal] = useState(false);
+  const [secondsIdle, setSecondsIdle] = useState(0);
   const [idleTimerWarn, setIdleTimerWarn] = useState<any>(undefined);
   const [logoutTimeout, setLogoutTimeout] = useState<any>(undefined);
   const history = useHistory();
+  const timerRef = useRef<NodeJS.Timeout | undefined>(undefined);
 
   const handleLogout = (): void => {
     // clear the logout timer
@@ -33,42 +35,58 @@ function AutoLogout(props: Props): React.ReactElement {
     props.setAutoLogout(true);
   };
 
-  const warnUserIdle = (): void => {
-    setShowModal(true);
-    // start the logout timer
-    const timeout = setTimeout(handleAutoLogout, timeFromWarnToLogout);
-    setLogoutTimeout(timeout);
+  const resetIdleTimer = (): void => {
+    setSecondsIdle(0);
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(handleAutoLogout, timeFromWarnToLogout);
   };
 
-  // closing idle modal warning
-  const handleClose = (): void => {
-    // reset the logout timer
-    clearTimeout(logoutTimeout);
-    setShowModal(false);
-    // reset the warn timer
-    idleTimerWarn.reset();
+  const onIdle = (): void => {
+    setShowModal(true);
+    resetIdleTimer();
   };
+
+  const onClose = (): void => {
+    setShowModal(false);
+    resetIdleTimer();
+  };
+
+  useEffect(() => {
+    window.addEventListener('mousemove', resetIdleTimer);
+    window.addEventListener('mousedown', resetIdleTimer);
+    window.addEventListener('keypress', resetIdleTimer);
+
+    return () => {
+      window.removeEventListener('mousemove', resetIdleTimer);
+      window.removeEventListener('mousedown', resetIdleTimer);
+      window.removeEventListener('keypress', resetIdleTimer);
+    };
+  }, []);
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setSecondsIdle((prevSecondsIdle) => prevSecondsIdle + 1);
+    }, 1000);
+
+    return () => clearInterval(intervalId);
+  }, []);
 
   return (
     <div>
       <IdleTimer
         key="idleTimerWarn"
-        ref={(ref) => { setIdleTimerWarn(ref); }}
+        ref={(ref) => {
+          setIdleTimerWarn(ref);
+        }}
         element={document}
-        onIdle={warnUserIdle}
+        onIdle={onIdle}
         debounce={250}
         timeout={timeUntilWarn}
         stopOnIdle
       />
-      <IdleTimeOutModal
-        showModal={showModal}
-        handleClose={handleClose}
-        handleLogout={handleLogout}
-      />
-      <DeviceSleepDetect
-        timeOut={timeBeforeConsideredSleep}
-        handleAutoLogout={handleAutoLogout}
-      />
+      <IdleTimeOutModal showModal={showModal} handleClose={onClose} handleLogout={handleLogout} />
+      <DeviceSleepDetect timeOut={timeBeforeConsideredSleep} handleAutoLogout={handleAutoLogout} />
+      <p>Seconds Idle: {secondsIdle}</p>
     </div>
   );
 }

--- a/src/components/UserAuthentication/AutoLogout.tsx
+++ b/src/components/UserAuthentication/AutoLogout.tsx
@@ -5,9 +5,9 @@ import { useHistory } from 'react-router-dom';
 import DeviceSleepDetect from './DeviceSleepDetect';
 import IdleTimeOutModal from './IdleTimeOutModal';
 
-const timeUntilWarn: number = 1000 * 10; // 10 minutes
-const timeFromWarnToLogout: number = 1000 * 5; // 5 minutes
-const timeBeforeConsideredSleep: number = 1000 * 60 * 2; // 2 minutes
+const timeUntilWarn: number = 1000 * 60 * 50; // 10 minutes
+const timeFromWarnToLogout: number = 1000 * 60 * 10; // 5 minutes
+const timeBeforeConsideredSleep: number = 1000 * 60 * 5; // 2 minutes
 
 interface Props {
   logOut: () => void;

--- a/src/tests/components/AutoLogout/AutoLogout.test.tsx
+++ b/src/tests/components/AutoLogout/AutoLogout.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { act } from 'react-test-renderer';
+
+import AutoLogout from '../../../components/UserAuthentication/AutoLogout';
+
+jest.useFakeTimers();
+
+describe('AutoLogout', () => {
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('should not show warn modal with mouse activity', () => {
+    act(() => {
+      // simulate mouse activity
+      window.dispatchEvent(new MouseEvent('mousemove', { bubbles: true }));
+      window.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    });
+
+    jest.advanceTimersByTime(1000 * 60 * 50); // 50 minutes
+
+    expect(screen.queryByTestId('warn-modal')).toBeNull();
+
+    jest.advanceTimersByTime(1000 * 60 * 10); // 10 minutes
+
+    expect(screen.queryByTestId('warn-modal')).toBeNull();
+  });
+
+  it('should show warn modal with keyboard activity', () => {
+    act(() => {
+      // simulate keyboard activity
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+    });
+
+    jest.advanceTimersByTime(1000 * 60 * 50); // 50 minutes
+
+    expect(screen.queryByTestId('warn-modal')).toBeNull();
+
+    jest.advanceTimersByTime(1000 * 60 * 10); // 10 minutes
+
+    expect(screen.queryByTestId('warn-modal')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Link to Issue
1. The previous code is incapable of detecting user behavior (mouse, keyboard) and resetting the timer to avoid auto logout. 
2. The previous code had no unit test.

## Description of changes

- AutoLogout:
  - Reduces the idle time limit from 2 hours to 50 minutes and the time from warning to logout from 1 minute to 10 minutes. 
  - Additionally, the time before the component is considered asleep has been reduced from 15 seconds to 5 seconds.

- Unit testing
  - Simulate mouse and keyboard activity and check that the warning modal is displayed after 50 minutes of inactivity and the user is logged out after 10 minutes. 
  - Check that user activity prevents the warning modal from being displayed.

## Screenshot(s) or GIF(s) of changes
