### PR TITLE
removed application form alert on client view

### DIFF
--- a/src/components/Applications/ApplicationForm.tsx
+++ b/src/components/Applications/ApplicationForm.tsx
@@ -671,7 +671,7 @@ class ApplicationForm extends Component<Props, State> {
           <meta name="description" content="Keep.id" />
         </Helmet>
         <div className="ml-5 mt-3">
-          <div className="alert alert-primary">You are currently filling out this application on behalf of {clientUsername}.</div>
+          {clientUsername && <div className="alert alert-primary">You are currently filling out this application on behalf of {clientUsername}.</div>}
           <Link to="/applications">
             <button type="button" className="btn btn-primary">
               Back


### PR DESCRIPTION
## Link to Issue
Application form alert ("You are filling out this form on behalf of {clientUsername}") was showing up in the client view. This was fixed to only appear in the case worker view.
## Description of changes

## Screenshot(s) or GIF(s) of changes
