### PR TITLE
set the mail button to only show from admin view applications page

### DIFF
--- a/src/components/Documents/ViewDocument.tsx
+++ b/src/components/Documents/ViewDocument.tsx
@@ -11,6 +11,7 @@ import { MailConfirmation, MailModal } from './MailModal';
 
 interface Props {
   alert: any;
+  // user role is set to client while viewing documents
   userRole: Role;
   documentId: string;
   documentName: string;
@@ -125,12 +126,14 @@ const ViewDocument: React.FC<Props> = ({ alert, userRole, documentId, documentNa
           </PrimaryButton>
         </Link>
 
-        <PrimaryButtonSolid onClick={() => setMailDialogIsOpen(true)}>
+        {userRole !== Role.Client && (
+<PrimaryButtonSolid onClick={() => setMailDialogIsOpen(true)}>
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="tw-w-6 tw-h-6 tw-pr-1 tw-inline tw-align-middle">
             <path strokeLinecap="round" strokeLinejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" />
           </svg>
           <span className="tw-align-middle tw-pt-[1px] tw-pl-1">Mail</span>
-        </PrimaryButtonSolid>
+</PrimaryButtonSolid>
+        )}
 
       </div>
 


### PR DESCRIPTION
## Link to Issue
Now mail option is only open when accessing applications from admin panel > View Applications > View
Mail option cannot be accessed from client or View Documents page.

## Description of changes

## Screenshot(s) or GIF(s) of changes
