### PR TITLE
Center header in ApplicationForm component

### DIFF
--- a/src/components/Applications/ApplicationForm.tsx
+++ b/src/components/Applications/ApplicationForm.tsx
@@ -548,7 +548,7 @@ class ApplicationForm extends Component<Props, State> {
                 style={{ width: `${fillAmt}%` }}
               />
             </div>
-            <div className="col-lg-10 col-md-10 col-sm-12">
+            <div className="col-lg-12 col-md-12 col-sm-12">
               <h2>{title}</h2>
               <p>{description}</p>
             </div>


### PR DESCRIPTION
## Link to Issue

The header in the application component was not centered as expected. This issue was initially raised in the engineering Slack channel on 11/02/2024.

## Description of changes

Adjusted the header div's column width in the application component to span 12 columns across all screen sizes, ensuring the header text is centered within the full width of the screen on any device.

## Screenshot(s) or GIF(s) of changes

<img width="1273" alt="Screenshot 2024-11-03 at 9 41 01 PM" src="https://github.com/user-attachments/assets/dda49f0b-a83f-4228-9627-04cf0ae1c650">
