### PR TITLE
fix(oauth): absolute redirect/origin URIs for Google + Microsoft login

### DIFF
--- a/src/components/UserAuthentication/GoogleLoginButton.tsx
+++ b/src/components/UserAuthentication/GoogleLoginButton.tsx
@@ -3,12 +3,6 @@ import React, { useEffect } from 'react';
 import getServerURL from '../../serverOverride';
 
 const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
-const currentMode = import.meta.env.MODE;
-const originUri = currentMode === 'production'
-  ? 'https://keep.id'
-  : currentMode === 'staging'
-    ? 'https://staged.keep.id'
-    : 'http://localhost:3000';
 
 export default function GoogleLoginButton({ handleGoogleLoginSuccess, handleGoogleLoginError }) {
   useEffect(() => {
@@ -22,12 +16,24 @@ export default function GoogleLoginButton({ handleGoogleLoginSuccess, handleGoog
   }, []);
 
   const handleClick = () => {
+    // Build an ABSOLUTE redirect URI. getServerURL() may return a relative
+    // path (e.g. "/api" in the Cloud Run prod build); Google rejects
+    // relative redirect_uri values. Prefixing with window.location.origin
+    // produces the full URL that the browser will navigate to after auth,
+    // which is also what must be registered in the Google OAuth client
+    // console AND in the server's keepid.oauth.allowed-redirect-uris
+    // allowlist. window.location.origin makes this self-correcting across
+    // every host the FE might be served from (keep.id, the Cloud Run
+    // preview URL, localhost, future custom domains).
+    const redirectUri = `${window.location.origin}${getServerURL()}/googleLoginResponse`;
+    const originUri = window.location.origin;
+
     fetch(`${getServerURL()}/googleLoginRequest`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify({
-        redirectUri: `${getServerURL()}/googleLoginResponse`,
+        redirectUri,
         originUri,
       }),
     })
@@ -40,7 +46,7 @@ export default function GoogleLoginButton({ handleGoogleLoginSuccess, handleGoog
           `client_id=${clientId}` +
           '&response_type=code' +
           '&scope=openid%20email%20profile' +
-          `&redirect_uri=${getServerURL()}/googleLoginResponse` +
+          `&redirect_uri=${encodeURIComponent(redirectUri)}` +
           `&state=${state}` +
           '&code_challenge_method=S256' +
           `&code_challenge=${codeChallenge}` +

--- a/src/components/UserAuthentication/MicrosoftLoginButton.tsx
+++ b/src/components/UserAuthentication/MicrosoftLoginButton.tsx
@@ -4,12 +4,6 @@ import getServerURL from '../../serverOverride';
 
 const clientId = import.meta.env.VITE_MICROSOFT_CLIENT_ID;
 const tenantId = import.meta.env.VITE_MICROSOFT_TENANT_ID || 'organizations';
-const currentMode = import.meta.env.MODE;
-const originUri = currentMode === 'production'
-  ? 'https://keep.id'
-  : currentMode === 'staging'
-    ? 'https://staged.keep.id'
-    : 'http://localhost:3000';
 
 export default function MicrosoftLoginButton({ handleMicrosoftLoginSuccess, handleMicrosoftLoginError }) {
   useEffect(() => {
@@ -28,12 +22,18 @@ export default function MicrosoftLoginButton({ handleMicrosoftLoginSuccess, hand
       return;
     }
 
+    // Absolute URLs from the live origin — see GoogleLoginButton for the
+    // detailed rationale. Build-mode-based hardcoded origins broke as
+    // soon as the FE was deployed at a non-canonical URL.
+    const redirectUri = `${window.location.origin}${getServerURL()}/microsoftLoginResponse`;
+    const originUri = window.location.origin;
+
     fetch(`${getServerURL()}/microsoftLoginRequest`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify({
-        redirectUri: `${getServerURL()}/microsoftLoginResponse`,
+        redirectUri,
         originUri,
       }),
     })
@@ -47,7 +47,7 @@ export default function MicrosoftLoginButton({ handleMicrosoftLoginSuccess, hand
             `client_id=${clientId}` +
             '&response_type=code' +
             '&scope=openid%20email%20profile' +
-            `&redirect_uri=${getServerURL()}/microsoftLoginResponse` +
+            `&redirect_uri=${encodeURIComponent(redirectUri)}` +
             `&state=${state}` +
             '&code_challenge_method=S256' +
             `&code_challenge=${codeChallenge}` +


### PR DESCRIPTION
## Summary
- Replaces build-mode-hardcoded `originUri` (`'https://keep.id'` in production) and relative `redirectUri` (`'/api/googleLoginResponse'` with `VITE_API_BASE=/api`) with absolute URLs constructed from `window.location.origin`. Self-correcting across every host the FE is deployed at.
- Adds `encodeURIComponent` on the `redirect_uri` query param in the constructed auth URL.

## Why
On `https://keepid-client-781052795839.us-east4.run.app/home`, clicking "Sign in with Google" surfaced "Could not initiate Google sign-in. Please try again." Network shows POST `/api/googleLoginRequest` returning 200 OK with body `{status: 'INVALID_REDIRECT_URI', ...}` (verified against `OAuthService#processLoginRequest`'s open-redirect guard against `keepid.oauth.allowed-redirect-uris`).

Two FE issues feeding the failure:
1. `redirectUri: \`\${getServerURL()}/googleLoginResponse\`` → `/api/googleLoginResponse` in prod build. Relative; rejected by the server allowlist and would have been rejected by Google anyway.
2. `originUri = 'https://keep.id'` hardcoded for `MODE === 'production'`. The FE on Cloud Run is NOT `keep.id`, so the server got the wrong "send the user back here after auth" hint.

Both fixed by using `window.location.origin`.

## Companion infra change
`keepid_infra/terraform/run.tf` adds `KEEPID_OAUTH_ALLOWED_REDIRECT_URIS` env var on the Cloud Run server with the six URLs the FE may legitimately produce:
- `https://keepid-client-781052795839.us-east4.run.app/api/{googleLoginResponse,microsoftLoginResponse}` (current preview)
- `https://keep.id/api/{googleLoginResponse,microsoftLoginResponse}` (post-cutover FE)
- `https://server.keep.id/{googleLoginResponse,microsoftLoginResponse}` (post-cutover direct backend)

That change is already applied to the running service.

## What still needs manual config (Google / Microsoft consoles)
The OAuth client's "Authorized redirect URIs" must include exactly what the FE sends. After this PR ships, the FE will send `https://keepid-client-781052795839.us-east4.run.app/api/googleLoginResponse` (Google) and `.../api/microsoftLoginResponse` (Microsoft). Currently you have `https://keepid-server-next-3olpn4bjhq-uk.a.run.app/googleLoginResponse` registered — Google will still reject because it doesn't match the new redirect_uri.

Add to **Google Cloud Console** (project keepid-302503) → APIs & Services → Credentials → OAuth 2.0 Client → Authorized redirect URIs:
- `https://keepid-client-781052795839.us-east4.run.app/api/googleLoginResponse`

Add to **Azure Portal** → App registrations → the keepid app → Authentication → Web → Redirect URIs:
- `https://keepid-client-781052795839.us-east4.run.app/api/microsoftLoginResponse`

(Leave the existing entries — `server.keep.id` and the keepid-server-next direct URL — in place. They're still valid for the post-cutover path.)

## Verify after deploy
1. Hard refresh or incognito on `https://keepid-client-781052795839.us-east4.run.app/home`.
2. Click Sign in with Google → should redirect to Google's consent screen with the correct redirect_uri in the URL.
3. Network tab → POST `/api/googleLoginRequest` returns `{status: 'REQUEST_SUCCESS', codeChallenge: ..., state: ...}`.
4. Complete the OAuth round-trip → user lands back on the FE logged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)