### PR TITLE
feat(enroll-worker): confirmation copy for email + temp password flow

### DIFF
--- a/src/components/SignUp/EnrollWorker.tsx
+++ b/src/components/SignUp/EnrollWorker.tsx
@@ -151,8 +151,10 @@ export default function EnrollWorkerPage(): JSX.Element {
           <p className="tw-text-gray-600 tw-mb-6">
             <strong>{values.firstname} {values.lastname}</strong> has been enrolled
             as a <strong>{values.personRole}</strong>.
-            They can log in via Google OAuth using <strong>{values.email}</strong>,
-            or set a password using Forgot Password on the login page.
+            We&apos;ve emailed sign-in instructions to{' '}
+            <strong>{values.email}</strong>. They can click the link in that
+            email to set a password, or sign in directly with Google or
+            Microsoft using their email.
           </p>
           <div className="tw-flex tw-justify-center tw-space-x-4">
             <button

--- a/src/components/SignUp/EnrollWorker.tsx
+++ b/src/components/SignUp/EnrollWorker.tsx
@@ -151,10 +151,9 @@ export default function EnrollWorkerPage(): JSX.Element {
           <p className="tw-text-gray-600 tw-mb-6">
             <strong>{values.firstname} {values.lastname}</strong> has been enrolled
             as a <strong>{values.personRole}</strong>.
-            We&apos;ve emailed sign-in instructions to{' '}
-            <strong>{values.email}</strong>. They can click the link in that
-            email to set a password, or sign in directly with Google or
-            Microsoft using their email.
+            We&apos;ve emailed a temporary password to{' '}
+            <strong>{values.email}</strong>. They can sign in with that
+            password, or use Google or Microsoft with their email.
           </p>
           <div className="tw-flex tw-justify-center tw-space-x-4">
             <button


### PR DESCRIPTION
## Summary
- Updates the Enroll Worker confirmation screen copy to match the new server behavior: workers now receive an email with a temporary password (plus a note about Google/Microsoft SSO with the same email).
- Pairs with keepid_server_next PR — server mints the temp password on enroll and ships it in the welcome email.

## Test plan
- [ ] Log in as admin → Enroll a new worker → confirmation screen reads "We've emailed a temporary password to <email>" and mentions Google/Microsoft as an alternative
- [ ] Worker receives the email and can sign in with the temp password OR with Google/Microsoft (server PR test plan covers this)

## Pairs with
- keepid_server_next: https://github.com/keepid/keepid_server_next/pull/54

🤖 Generated with [Claude Code](https://claude.com/claude-code)