### PR TITLE
ci(deploy): smoke-test against / instead of /healthz

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,16 +78,23 @@ jobs:
             --project=${{ env.PROJECT_ID }} \
             --format='value(status.url)')
           echo "Service URL: $URL"
+          # Hit the SPA root, not /healthz: Google's frontend
+          # intercepts the literal path "/healthz" on *.run.app
+          # before it reaches the container (likely a reserved
+          # k8s-convention path at the GFE layer), so external
+          # probes there always 404 even though the container's
+          # nginx serves it for Cloud Run's own internal probes.
+          # `/` reaches the container and returns 200 for index.html.
           # Allow up to 90s for the new revision to become serving.
           for i in {1..18}; do
-            if curl -fsS "$URL/healthz" > /dev/null; then
-              echo "healthz OK"
+            if curl -fsS "$URL/" > /dev/null; then
+              echo "root OK"
               exit 0
             fi
             echo "waiting for new revision... ($i/18)"
             sleep 5
           done
-          echo "healthz probe did not pass within 90s" >&2
+          echo "root probe did not pass within 90s" >&2
           gcloud run services logs read ${{ env.SERVICE }} \
             --region=${{ env.REGION }} --project=${{ env.PROJECT_ID }} \
             --limit=50


### PR DESCRIPTION
## Summary

The first auto-deploy run from [#606](https://github.com/keepid/keepid_client/pull/606) failed at the smoke-test step — every poll returned 404 for \`/healthz\`. Investigation showed Cloud Run's edge (GFE) intercepts the literal path \`/healthz\` on \`*.run.app\` URLs before requests reach the container. Reproducible on the unrelated \`keepid-server-next\` service too. Cloud Run's *own* startup/liveness probes use a different internal pathway and continue to get a 200 from nginx — so the service itself was healthy, only the external probe was broken.

Switch the workflow's smoke probe to \`/\`. nginx serves \`index.html\`, returns 200, and proves both that the new revision is rolled and that the SPA is being served.

\`run_client.tf\`'s \`startup_probe\` / \`liveness_probe\` still use \`/healthz\` — those are internal and work fine.

## Test plan

- [ ] Merge → first run should reach the smoke step on the next push and pass
- [ ] Confirm in the Actions log that \`root OK\` is printed
- [ ] Confirm Cloud Run revision count increments and traffic moves to the new one

🤖 Generated with [Claude Code](https://claude.com/claude-code)