### PR TITLE
refactor(phone): centralize phone display, match server canonicalization

### DIFF
--- a/src/components/LandingPages/WorkerLanding.tsx
+++ b/src/components/LandingPages/WorkerLanding.tsx
@@ -8,6 +8,7 @@ import getServerURL from '../../serverOverride';
 import GenericProfilePicture from '../../static/images/generalprofilepic.png';
 import VisualizationSVG from '../../static/images/visualization.svg';
 import Role from '../../static/Role';
+import { formatPhoneForDisplay } from '../../utils/phone';
 import IdPickupNotificationForm from '../Notifications/IdPickupNotificationForm';
 
 interface Props {
@@ -458,7 +459,7 @@ const WorkerLanding: React.FC<Props> = ({ username, name, organization, alert })
                               </h5>
                             </div>
                             <div className="tw-mb-1">
-                              <h6 className="tw-text-gray-500">{client.phone}</h6>
+                              <h6 className="tw-text-gray-500">{formatPhoneForDisplay(client.phone)}</h6>
                             </div>
                             <div className="tw-mb-1">
                               <h6 className="tw-text-gray-500">

--- a/src/components/PhoneBook/PhoneBookManager.tsx
+++ b/src/components/PhoneBook/PhoneBookManager.tsx
@@ -3,6 +3,7 @@ import { useAlert } from 'react-alert';
 
 import { isValidPhoneNumber } from '../../lib/Validations/Validations';
 import getServerURL from '../../serverOverride';
+import { formatPhoneForDisplay } from '../../utils/phone';
 
 type PhoneBookEntry = {
   label: string;
@@ -262,7 +263,7 @@ export default function PhoneBookManager({ targetUsername, onPhoneBookChanged }:
                         </span>
                       )}
                       <div className="tw-text-sm tw-text-gray-500">
-                        {formatPhone(entry.phoneNumber)}
+                        {formatPhoneForDisplay(entry.phoneNumber)}
                       </div>
                     </div>
                     <div className="tw-flex tw-gap-1 tw-flex-shrink-0">
@@ -344,12 +345,4 @@ export default function PhoneBookManager({ targetUsername, onPhoneBookChanged }:
       </div>
     </div>
   );
-}
-
-function formatPhone(phone: string): string {
-  const digits = phone.replace(/[^0-9]/g, '');
-  if (digits.length === 10) {
-    return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
-  }
-  return phone;
 }

--- a/src/components/PhoneBook/PhoneBookPicker.tsx
+++ b/src/components/PhoneBook/PhoneBookPicker.tsx
@@ -3,6 +3,7 @@ import { useAlert } from 'react-alert';
 
 import { isValidPhoneNumber } from '../../lib/Validations/Validations';
 import getServerURL from '../../serverOverride';
+import { formatPhoneForDisplay } from '../../utils/phone';
 
 export type PhoneBookEntry = {
   label: string;
@@ -131,7 +132,7 @@ export default function PhoneBookPicker({
           <option key={entry.phoneNumber} value={entry.phoneNumber}>
             {entry.label}
             {' — '}
-            {formatPhoneDisplay(entry.phoneNumber)}
+            {formatPhoneForDisplay(entry.phoneNumber)}
           </option>
         ))}
         <option value="__add__">+ Add a new number</option>
@@ -177,12 +178,4 @@ export default function PhoneBookPicker({
       )}
     </div>
   );
-}
-
-function formatPhoneDisplay(phone: string): string {
-  const digits = phone.replace(/[^0-9]/g, '');
-  if (digits.length === 10) {
-    return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
-  }
-  return phone;
 }

--- a/src/components/Profile/EssentialAccountSection.tsx
+++ b/src/components/Profile/EssentialAccountSection.tsx
@@ -8,6 +8,7 @@ import {
   isValidPhoneNumber,
 } from '../../lib/Validations/Validations';
 import getServerURL from '../../serverOverride';
+import { formatPhoneForDisplay } from '../../utils/phone';
 import { birthDateStringFromIsoDateOnly } from '../SignUp/SignUp.util';
 import type { NameObj, ProfileData } from './ProfilePage';
 
@@ -49,14 +50,6 @@ function accountNameEqual(a: NameObj, b: NameObj): boolean {
     && (a.middle || '') === (b.middle || '')
     && (a.last || '') === (b.last || '')
     && (a.suffix || '') === (b.suffix || '');
-}
-
-function formatPhone(phone: string): string {
-  const digits = phone.replace(/[^0-9]/g, '');
-  if (digits.length === 10) {
-    return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
-  }
-  return phone;
 }
 
 export default function EssentialAccountSection({
@@ -633,7 +626,7 @@ export default function EssentialAccountSection({
                 ) : (
                   phoneBook.map((entry) => (
                     <div key={entry.phoneNumber} className="tw-pt-2 tw-flex tw-items-center tw-gap-2">
-                      <span>{formatPhone(entry.phoneNumber)}</span>
+                      <span>{formatPhoneForDisplay(entry.phoneNumber)}</span>
                       <span className="tw-text-sm tw-text-gray-500">{entry.label}</span>
                     </div>
                   ))

--- a/src/lib/Validations/Validations.ts
+++ b/src/lib/Validations/Validations.ts
@@ -7,8 +7,12 @@ const validCharacters: string =
     "a-zA-ZàáâäãåąčćęèéêëėįìíîïłńòóôöõøùúûüųūÿýżźñçčšžÀÁÄÃÅĄĆČĖĘÈÉÊËÌÍÎÏĮŁŃÒÓÔÖÕØÙÚÛÜŲŪŸÝŻŹÑßÇŒÆČŠŽ∂ð";
 const emailPattern: RegExp =
     new RegExp("^[" + validCharacters + "0-9_!#$%&’*+=?`{|}~^.-]{1,150}@[a-zA-Z0-9.-]{1,150}$");
-const phoneNumberPattern: RegExp =
-    new RegExp("^(\\+)?\\(?(1)?\\)?(-)?(\\d{10}|(?:\\d{3}-){2}\\d{4}|\\(\\d{3}\\)(-)?\\d{3}-?\\d{4})$");
+// Liberal in what we accept: anything that reduces to 10 digits (with an
+// optional leading +1 or 1) is considered valid. The server's
+// PhoneNumbers#toCanonical applies the same rule, so the FE validator
+// rejecting "(215) 555-1212" while the server accepts it was the older
+// source of the worker-card/profile drift bug.
+const phoneDigitsOnly = (input: string): string => input.replace(/\D/g, "");
 const birthDatePattern: RegExp = new RegExp("^[0-9]{2}-[0-9]{2}-[0-9]{4}$");
 const zipCodePattern: RegExp = new RegExp("^([0-9]{5}(?:-[0-9]{4})?)$");
 const cityPattern: RegExp =
@@ -37,9 +41,10 @@ let isValidEmail = (input: string): boolean => {
 }
 
 let isValidPhoneNumber = (input: string): boolean => {
-    return input !== null
-        && !(input.trim() === "")
-        && phoneNumberPattern.test(input);
+    if (input == null || input.trim() === "") return false;
+    const digits = phoneDigitsOnly(input);
+    const trimmed = digits.length === 11 && digits.startsWith("1") ? digits.slice(1) : digits;
+    return trimmed.length === 10;
 }
 
 let isValidBirthDate = (input: string): boolean => {

--- a/src/utils/phone.ts
+++ b/src/utils/phone.ts
@@ -1,0 +1,30 @@
+// Display- and storage-side helpers for US phone numbers, kept in sync with
+// the server's `PhoneNumbers` utility so the worker landing card, the
+// profile phone-book panel, and the picker all render the same value
+// regardless of what format the user originally typed.
+
+/**
+ * Returns the 10-digit canonical form of `raw`, or `null` if it cannot be
+ * parsed into a valid US number. Liberal in what it accepts: digits,
+ * dashes, dots, spaces, parens, and an optional leading `+1` or `1`.
+ */
+export function canonicalizePhone(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  const digits = raw.replace(/\D/g, '');
+  const stripped = digits.length === 11 && digits.startsWith('1') ? digits.slice(1) : digits;
+  return stripped.length === 10 ? stripped : null;
+}
+
+/**
+ * Formats a US phone number as `(XXX) XXX-XXXX` when it can be reduced to
+ * 10 canonical digits. Anything we can't parse comes back unchanged so the
+ * raw value is at least visible to the user — important during the
+ * migration window when legacy rows may still hold non-canonical strings
+ * the V9 backfill couldn't salvage.
+ */
+export function formatPhoneForDisplay(phone: string | null | undefined): string {
+  if (phone == null || phone === '') return '';
+  const canonical = canonicalizePhone(phone);
+  if (canonical === null) return phone;
+  return `(${canonical.slice(0, 3)}) ${canonical.slice(3, 6)}-${canonical.slice(6)}`;
+}


### PR DESCRIPTION
## Summary

Worker landing card was rendering `client.phone` raw — anything the
worker typed at enrollment came back unformatted, while the profile
phone-book panel ran its own private formatter. With
[keepid_server_next#55](https://github.com/keepid/keepid_server_next/pull/55)
sending canonical 10-digit strings, the FE only needs one display
helper everywhere.

Pairs with `ai/fix-phonebook-enrollment-sync` on server-next — both must
land for the visible regression (profile page showing *"No phone numbers
saved"* while the worker card showed the phone) to clear. Targets the
`server-migration` branch per the migration playbook.

## What's in the change

- **New util** `src/utils/phone.ts`:
  - `canonicalizePhone` — mirrors the server's `PhoneNumbers#toCanonical`.
  - `formatPhoneForDisplay` — `(XXX) XXX-XXXX` for 10-digit canonical
    input; passthrough for non-canonical legacy rows the V9 backfill
    couldn't salvage so the user still sees something.
- **WorkerLanding** card uses it instead of rendering `client.phone` raw.
- **EssentialAccountSection / PhoneBookManager / PhoneBookPicker** drop
  three local copies of the same formatter.
- **`isValidPhoneNumber`** relaxed to match the server: anything that
  reduces to 10 digits passes. The old regex rejected `(215) 555-1212`
  (with the space) even though the server happily accepted it — one of
  the original sources of the worker-card/profile drift.

## Test plan

- [x] `npx tsc --noEmit` — no new errors from touched files.
- [x] `npm run lint` on touched files — clean after autofix.
- [x] `vite build` — green.
- [x] Claude Preview against dockerized `keepid_server_next` running
      the `ai/fix-phonebook-enrollment-sync` branch:
  - Enrolled clients with `2672661079`, `+12159645845`, `(267) 555-3434`,
    and no-phone. Worker card renders each as `(XXX) XXX-XXXX`.
  - Visited `/profile/<each-username>` — the **Phone Numbers** row
    displays the same `(XXX) XXX-XXXX` value tagged `primary`. The
    previous "No phone numbers saved" regression is gone for both the
    +1 and no-+1 enrollment formats.
  - Adding a phone to an enrolled-without-phone client via the profile
    edit UI also surfaces it on the worker landing card after refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)