### PR TITLE
feat(ui): batch of client UI polish tweaks

### DIFF
--- a/src/components/AccountSettings/MyOrganization.tsx
+++ b/src/components/AccountSettings/MyOrganization.tsx
@@ -9,6 +9,7 @@ import { Link } from 'react-router-dom';
 import getServerURL from '../../serverOverride';
 import FileType from '../../static/FileType';
 import Role from '../../static/Role';
+import { formatPhoneForDisplay } from '../../utils/phone';
 import DataTable, { DataTableColumn } from '../BaseComponents/DataTable';
 import RowActionMenu, { RowAction } from '../BaseComponents/RowActionMenu';
 import ViewDocument from '../Documents/ViewDocument';
@@ -688,7 +689,7 @@ const MyOrganization: React.FC<Props> = ({ name, organization, role, alert }) =>
         </div>
         <div className="row tw-mb-2 tw-mt-1">
           <div className="col-3 card-text mt-2 text-primary-theme">Phone</div>
-          <div className="col-9 card-text tw-pt-2">{orgInfo.phone || 'Not set'}</div>
+          <div className="col-9 card-text tw-pt-2">{orgInfo.phone ? formatPhoneForDisplay(orgInfo.phone) : 'Not set'}</div>
         </div>
         <div className="row tw-mb-2 tw-mt-1">
           <div className="col-3 card-text mt-2 text-primary-theme">Email</div>

--- a/src/components/AccountSettings/MyOrganization.tsx
+++ b/src/components/AccountSettings/MyOrganization.tsx
@@ -1,11 +1,10 @@
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import DriveFileRenameOutlineIcon from '@mui/icons-material/DriveFileRenameOutline';
+import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { withAlert } from 'react-alert';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
-
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import DriveFileRenameOutlineIcon from '@mui/icons-material/DriveFileRenameOutline';
-import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
 
 import getServerURL from '../../serverOverride';
 import FileType from '../../static/FileType';
@@ -91,6 +90,15 @@ function formatAddress(a: OrgAddress): string {
   return [a.line1, a.line2, a.city, a.state, a.zip].filter(Boolean).join(', ');
 }
 
+// Format a Date as YYYY-MM-DD using local calendar fields. Avoids the UTC skew
+// of toISOString(), which can roll the date back a day for users west of UTC.
+function toLocalISODate(d: Date): string {
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 interface OrgDocument {
   id: string;
   filename: string;
@@ -153,10 +161,10 @@ const MyOrganization: React.FC<Props> = ({ name, organization, role, alert }) =>
   const [isLoadingMailSummary, setIsLoadingMailSummary] = useState(false);
   const [mailDateFrom, setMailDateFrom] = useState(() => {
     const d = new Date();
-    d.setDate(d.getDate() - 30);
-    return d.toISOString().split('T')[0];
+    d.setDate(1);
+    return toLocalISODate(d);
   });
-  const [mailDateTo, setMailDateTo] = useState(() => new Date().toISOString().split('T')[0]);
+  const [mailDateTo, setMailDateTo] = useState(() => toLocalISODate(new Date()));
 
   const [orgDocs, setOrgDocs] = useState<OrgDocument[]>([]);
   const [isLoadingDocs, setIsLoadingDocs] = useState(false);

--- a/src/components/Applications/ApplicationCard.tsx
+++ b/src/components/Applications/ApplicationCard.tsx
@@ -44,7 +44,7 @@ export default function SelectApplicationCard({
         tw-rounded-xl tw-shadow-[0px_0px_10px_4px_rgba(0,0,0,0.12)] tw-p-4
         ${defaultState ? 'tw-bg-transparent tw-text-black hover:tw-bg-gray-100 hover:tw-text-black !tw-border-gray-300 hover:!tw-border-gray-500 ' : ''}
         ${disabled ? '!tw-bg-gray-300 tw-text-black !tw-border-gray-500' : ''}
-        ${checked ? '!tw-bg-indigo-100 !tw-border-gray-500 !tw-shadow-[0px_0px_10px_4px_rgba(0,0,0,0.35)]' : ''}`}
+        ${checked ? '!tw-bg-indigo-200 !tw-border-gray-600 !tw-shadow-[0px_0px_12px_5px_rgba(0,0,0,0.4)]' : ''}`}
     >
       <img alt={iconAlt} src={iconSrc} className="tw-my-5 tw-h-28 sm:tw-h-32 tw-w-auto tw-aspect-auto tw-pointer-events-none" />
       <p className={

--- a/src/components/BaseComponents/Inputs/StructuredFormWithRows.tsx
+++ b/src/components/BaseComponents/Inputs/StructuredFormWithRows.tsx
@@ -30,7 +30,7 @@ export default function StructuredFormWithRows({
   return (
     <Form onSubmit={onSubmit}>
       {rows.map((r) => (
-        <Row key={`form-row-${r.rowLabel}`} className="text-end">
+        <Row key={`form-row-${r.rowLabel}`} className="text-end align-items-center">
           <p className="col-sm-3 col-form-label tw-mx-2 tw-my-3">{r.rowLabel}</p>
           {r.fields.map((f) => (
             <Col key={`input-${f.name}`}>

--- a/src/components/Documents/MyDocuments.tsx
+++ b/src/components/Documents/MyDocuments.tsx
@@ -622,7 +622,7 @@ class MyDocuments extends Component<Props, State> {
       },
     ];
     const mostRecentColumns: DataTableColumn[] = allDocumentsColumns.filter(
-      (column) => column.field !== 'uploadDate' && column.field !== 'uploader',
+      (column) => column.field !== 'uploader',
     );
 
     return (

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -174,7 +174,7 @@ const Footer = () => {
           </div>
           <p className="tw-text-xs tw-text-white tw-text-center my-0">Keep.id is proud to be a 501(c)(3) tax-exempt non-profit organization.</p>
           <p className="tw-text-xs tw-text-white tw-text-center my-1">Illustrations by Storyset. Environment: {currentMode}</p>
-          <p className="tw-text-xs tw-text-white tw-text-center my-0">&copy; 2025 Keep.id</p>
+          <p className="tw-text-xs tw-text-white tw-text-center my-0">&copy; {new Date().getFullYear()} Keep.id</p>
         </div>
       </div>
     </footer>

--- a/src/components/LandingPages/WorkerLanding.tsx
+++ b/src/components/LandingPages/WorkerLanding.tsx
@@ -124,7 +124,7 @@ const WorkerLanding: React.FC<Props> = ({ username, name, organization, alert })
   const [clientCredentialsCorrect, setClientCredentialsCorrect] = useState(false);
   const [showClientAuthModal, setShowClientAuthModal] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
-  const [sortMode, setSortMode] = useState<ClientSortMode>('name-asc');
+  const [sortMode, setSortMode] = useState<ClientSortMode>('date-desc');
   const [isLoading, setIsLoading] = useState(true);
   const { path, url } = useRouteMatch();
 
@@ -283,8 +283,9 @@ const WorkerLanding: React.FC<Props> = ({ username, name, organization, alert })
     return sortedClients.slice(indexOfFirstPost, indexOfLastPost);
   }, [sortedClients, currentPage]);
 
+  const lastPage = Math.max(Math.ceil(sortedClients.length / POSTS_PER_PAGE), 1);
+
   const { pageNumbers, paginationClassName } = useMemo(() => {
-    const lastPage = Math.ceil(sortedClients.length / POSTS_PER_PAGE);
     const pageNumbers: number[] = [];
     for (let i = 1; i <= lastPage; i += 1) {
       pageNumbers.push(i);
@@ -295,15 +296,18 @@ const WorkerLanding: React.FC<Props> = ({ username, name, organization, alert })
       const activeClasses = 'tw-bg-twprimary tw-text-white tw-border-blue-600';
       const inactiveClasses = 'tw-bg-white hover:tw-bg-gray-100';
 
-      let classes = `${baseClasses} ${pageNum === currentPage ? activeClasses : inactiveClasses}`;
-      if (pageNum === 1) classes += ' tw-rounded-l-md';
-      if (pageNum === lastPage) classes += ' tw-rounded-r-md';
-
-      return classes;
+      return `${baseClasses} ${pageNum === currentPage ? activeClasses : inactiveClasses}`;
     };
 
     return { pageNumbers, paginationClassName };
-  }, [sortedClients.length, currentPage]);
+  }, [lastPage, currentPage]);
+
+  const edgeButtonClassName = (disabled: boolean, side: 'left' | 'right'): string => {
+    const base = `tw-px-3 tw-py-1 tw-border tw-border-gray-300 ${side === 'left' ? 'tw-rounded-l-md' : 'tw-rounded-r-md'}`;
+    return disabled
+      ? `${base} tw-bg-gray-100 tw-text-gray-400 tw-cursor-not-allowed`
+      : `${base} tw-bg-white hover:tw-bg-gray-100 tw-cursor-pointer`;
+  };
 
   const modalRender = () => {
     if (!showClientAuthModal) return null;
@@ -397,11 +401,11 @@ const WorkerLanding: React.FC<Props> = ({ username, name, organization, alert })
 
               <div className="tw-flex tw-flex-col md:tw-flex-row md:tw-items-end tw-items-stretch tw-gap-4">
                 <form
-                  className="tw-flex tw-w-full md:tw-w-auto tw-flex-shrink-0"
+                  className="tw-flex tw-w-full md:tw-w-[28rem] tw-flex-shrink-0"
                   onSubmit={handleSearchSubmit}
                 >
                   <input
-                    className="tw-flex-grow tw-px-3 tw-py-2 tw-border tw-border-gray-300 tw-rounded-l-md focus:tw-ring-blue-500 focus:tw-border-blue-500"
+                    className="tw-flex-grow tw-px-4 tw-py-2.5 tw-text-base tw-border tw-border-gray-300 tw-rounded-l-md focus:tw-ring-blue-500 focus:tw-border-blue-500"
                     type="text"
                     onChange={(e) => setSearchName(e.target.value)}
                     value={searchName}
@@ -441,7 +445,7 @@ const WorkerLanding: React.FC<Props> = ({ username, name, organization, alert })
                   {sortedClients.length > 0 ? (
                     <div className="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 lg:tw-grid-cols-3 tw-gap-4">
                       {currentPosts.map((client) => (
-                        <div key={client.username} className="tw-bg-white tw-shadow-lg tw-rounded-lg tw-p-8 tw-flex tw-flex-col hover:tw-border-1 hover:tw-bg-gray-50">
+                        <div key={client.username} className="tw-bg-white tw-shadow-[0_-3px_10px_rgba(0,0,0,0.05),0_6px_16px_rgba(0,0,0,0.10)] tw-rounded-lg tw-p-8 tw-flex tw-flex-col hover:tw-border-1 hover:tw-bg-gray-50">
                           <Link
                             to={`/profile/${client.username}`}
                             className="tw-flex-grow tw-block tw-text-inherit hover:tw-no-underline tw-cursor-pointer"
@@ -526,6 +530,15 @@ const WorkerLanding: React.FC<Props> = ({ username, name, organization, alert })
                       {sortedClients.length} Results
                     </div>
                     <div className="tw-flex">
+                      <span
+                        className={edgeButtonClassName(currentPage === 1, 'left')}
+                        onClick={() => currentPage > 1 && setCurrentPage(currentPage - 1)}
+                        role="button"
+                        tabIndex={0}
+                        onKeyPress={(e) => e.key === 'Enter' && currentPage > 1 && setCurrentPage(currentPage - 1)}
+                      >
+                        Previous
+                      </span>
                       {pageNumbers.map((pageNum) => (
                         <span
                           key={pageNum}
@@ -538,6 +551,15 @@ const WorkerLanding: React.FC<Props> = ({ username, name, organization, alert })
                           {pageNum}
                         </span>
                       ))}
+                      <span
+                        className={edgeButtonClassName(currentPage === lastPage, 'right')}
+                        onClick={() => currentPage < lastPage && setCurrentPage(currentPage + 1)}
+                        role="button"
+                        tabIndex={0}
+                        onKeyPress={(e) => e.key === 'Enter' && currentPage < lastPage && setCurrentPage(currentPage + 1)}
+                      >
+                        Next
+                      </span>
                     </div>
                   </>
                 )}

--- a/src/components/Profile/OrganizationInfoSection.tsx
+++ b/src/components/Profile/OrganizationInfoSection.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
 import getServerURL from '../../serverOverride';
+import { formatPhoneForDisplay } from '../../utils/phone';
 
 type Props = {
   organizationName: string;
@@ -104,7 +105,7 @@ export default function OrganizationInfoSection({ organizationName }: Props) {
         {orgInfo.phone && (
           <div className="row tw-mb-2 tw-mt-1">
             <div className="col-3 card-text mt-2 text-primary-theme">Phone</div>
-            <div className="col-9 card-text tw-pt-2">{orgInfo.phone}</div>
+            <div className="col-9 card-text tw-pt-2">{formatPhoneForDisplay(orgInfo.phone)}</div>
           </div>
         )}
 

--- a/src/components/Profile/RecentActivity.tsx
+++ b/src/components/Profile/RecentActivity.tsx
@@ -14,8 +14,10 @@ function RecentActivity({ username }) {
   const renderActivitiesCard = (activities) => {
     if (activities.length > 0) {
       // eslint-disable-next-line no-underscore-dangle
-      return activities
-        .slice(0, 5) // only get the first number of elements
+      return [...activities]
+        .sort((a, b) =>
+          new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime())
+        .slice(0, 5) // only get the most recent elements
         .map((activity) => (
           <li className="odd:tw-bg-gray-100">
             <div className="tw-text-md tw-text-gray-700 tw-py-5 sm:tw-grid sm:tw-grid-cols-5">

--- a/src/components/UserAuthentication/LoginPage.tsx
+++ b/src/components/UserAuthentication/LoginPage.tsx
@@ -274,7 +274,9 @@ class LoginPage extends Component<Props, State> {
 
     return (
       <div className="form-signin pt-2">
-        {embedded ? null : <h1 className="h3 mb-3 font-weight-normal">Sign in</h1>}
+        <div className="tw-bg-gray-100 tw-rounded-lg tw-py-2 tw-px-4 tw-mb-3 tw-text-center">
+          <h1 className="h4 tw-font-semibold tw-mb-0">Sign In</h1>
+        </div>
         <GoogleLoginButton
           handleGoogleLoginSuccess={this.handleGoogleLoginSuccess}
           handleGoogleLoginError={this.handleGoogleLoginError}

--- a/src/components/UserAuthentication/LoginPage.tsx
+++ b/src/components/UserAuthentication/LoginPage.tsx
@@ -274,9 +274,7 @@ class LoginPage extends Component<Props, State> {
 
     return (
       <div className="form-signin pt-2">
-        <div className="tw-bg-gray-100 tw-rounded-lg tw-py-2 tw-px-4 tw-mb-3 tw-text-center">
-          <h1 className="h4 tw-font-semibold tw-mb-0">Sign In</h1>
-        </div>
+        <h1 className="h4 tw-font-semibold tw-mb-3 tw-text-center">Sign In</h1>
         <GoogleLoginButton
           handleGoogleLoginSuccess={this.handleGoogleLoginSuccess}
           handleGoogleLoginError={this.handleGoogleLoginError}

--- a/src/static/styles/App.scss
+++ b/src/static/styles/App.scss
@@ -257,6 +257,22 @@ thead {
 	border-radius: 0.35rem;
 }
 
+// Join an appended addon (e.g. the password reveal eye) seamlessly to its
+// input: flatten the input's right corners only when an addon follows, and
+// make the addon match the input's border, height, and rounded right edge.
+.input-group > .form-purple:not(:last-child) {
+	border-top-right-radius: 0;
+	border-bottom-right-radius: 0;
+}
+
+.input-group-append > .input-group-text {
+	height: 100%;
+	border: 0.0625rem solid $primary-theme;
+	border-left: 0;
+	border-top-left-radius: 0;
+	border-bottom-left-radius: 0;
+}
+
 .form-red {
 	border: 0.0625rem solid red;
 	border-radius: 0;
@@ -661,20 +677,30 @@ div.scrollbar {
 .pass-wrapper {
 	position: relative;
 	display: flex;
+	align-items: center;
 	margin-bottom: 0.875rem;
 }
 
 .pass-icon {
 	position: absolute;
-	top: 0.625rem;
-	right: 0.625rem;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0 0.75rem;
 	background-color: transparent;
 	border: none;
+	border-top-right-radius: inherit;
+	border-bottom-right-radius: inherit;
 	background-repeat: no-repeat;
 	cursor: pointer;
 }
 
 .pass-input {
+	flex: 1;
+	padding-right: 2.5rem;
 	border: none;
 	outline: none;
 }

--- a/src/utils/phone.ts
+++ b/src/utils/phone.ts
@@ -16,15 +16,16 @@ export function canonicalizePhone(raw: string | null | undefined): string | null
 }
 
 /**
- * Formats a US phone number as `(+1) XXX-XXX-XXXX` when it can be reduced to
- * 10 canonical digits. Anything we can't parse comes back unchanged so the
- * raw value is at least visible to the user — important during the
- * migration window when legacy rows may still hold non-canonical strings
- * the V9 backfill couldn't salvage.
+ * Formats a US phone number as `(XXX) XXX - XXXX` when it can be reduced to
+ * 10 canonical digits (all numbers are assumed to be US, so no country code
+ * is shown). Anything we can't parse comes back unchanged so the raw value is
+ * at least visible to the user — important during the migration window when
+ * legacy rows may still hold non-canonical strings the V9 backfill couldn't
+ * salvage.
  */
 export function formatPhoneForDisplay(phone: string | null | undefined): string {
   if (phone == null || phone === '') return '';
   const canonical = canonicalizePhone(phone);
   if (canonical === null) return phone;
-  return `(+1) ${canonical.slice(0, 3)}-${canonical.slice(3, 6)}-${canonical.slice(6)}`;
+  return `(${canonical.slice(0, 3)}) ${canonical.slice(3, 6)} - ${canonical.slice(6)}`;
 }

--- a/src/utils/phone.ts
+++ b/src/utils/phone.ts
@@ -16,7 +16,7 @@ export function canonicalizePhone(raw: string | null | undefined): string | null
 }
 
 /**
- * Formats a US phone number as `(XXX) XXX-XXXX` when it can be reduced to
+ * Formats a US phone number as `(+1) XXX-XXX-XXXX` when it can be reduced to
  * 10 canonical digits. Anything we can't parse comes back unchanged so the
  * raw value is at least visible to the user — important during the
  * migration window when legacy rows may still hold non-canonical strings
@@ -26,5 +26,5 @@ export function formatPhoneForDisplay(phone: string | null | undefined): string 
   if (phone == null || phone === '') return '';
   const canonical = canonicalizePhone(phone);
   if (canonical === null) return phone;
-  return `(${canonical.slice(0, 3)}) ${canonical.slice(3, 6)}-${canonical.slice(6)}`;
+  return `(+1) ${canonical.slice(0, 3)}-${canonical.slice(3, 6)}-${canonical.slice(6)}`;
 }


### PR DESCRIPTION
## Summary

A batch of small client-side UI polish tweaks on `server-migration`. Each is cosmetic or a small UX improvement — no API or data-model changes. Verified locally against the seeded dev backend (port 7001) logged in as demo-admin.

### Changes
1. **Footer** — copyright year is now dynamic (`new Date().getFullYear()`).
2. **Recent activity** (Profile) — sorts by `occurredAt` newest-first.
3. **Client cards** (All Clients) — added a subtle top shadow.
4. **Application card** — darker styling for the selected card.
5. **All Clients** — default sort is now "Account created (newest first)"; search bar is wider.
6. **All Clients** — added Previous / Next page buttons with disabled edge states.
7. **Documents** — "Most Recent" table now shows the **Uploaded** column.
8. **Mail summary** (My Organization) — defaults to the current month (1st → today); datepickers remain editable. Uses local-date formatting to avoid a UTC off-by-one.
9. **Phone display** — `(+1) XXX-XXX-XXXX` format in org/member info (shared `utils/phone`), applied consistently on both the Profile org section and the My Organization info section.
10. **Org signup** — labels align middle-right with their input rows.
11. **Password reveal icon** — matches input height; fixed the rounded-border gap between the input and the eye button.
12. **Login card** — added a "Sign In" header in a light-gray rounded container.

## Screenshots

_Desktop (left) and mobile (right), matched on height._

**Login — "Sign In" container + aligned reveal icon (#11, #12)**

<table><tr>
<td><img src="https://raw.githubusercontent.com/keepid/keepid_client/5c39e14674bf281bc7143c7ce27153c92b20cd54/screenshots/01-login-signin.png" height="380"></td>
<td><img src="https://raw.githubusercontent.com/keepid/keepid_client/5c39e14674bf281bc7143c7ce27153c92b20cd54/screenshots/m01-login-signin.png" height="380"></td>
</tr></table>

**All Clients — top-shadow cards, newest-first default sort, wider search, Previous/Next paging (#3, #5, #6)**

<table><tr>
<td><img src="https://raw.githubusercontent.com/keepid/keepid_client/5c39e14674bf281bc7143c7ce27153c92b20cd54/screenshots/03-all-clients.png" height="380"></td>
<td><img src="https://raw.githubusercontent.com/keepid/keepid_client/5c39e14674bf281bc7143c7ce27153c92b20cd54/screenshots/m03-all-clients.png" height="380"></td>
</tr></table>

**Profile — organization phone formatted as `(+1) 215-555-0100` (#9)**

<table><tr>
<td><img src="https://raw.githubusercontent.com/keepid/keepid_client/5c39e14674bf281bc7143c7ce27153c92b20cd54/screenshots/04-profile-phone.png" height="380"></td>
<td><img src="https://raw.githubusercontent.com/keepid/keepid_client/5c39e14674bf281bc7143c7ce27153c92b20cd54/screenshots/m04-profile-phone.png" height="380"></td>
</tr></table>

**Documents — "Most Recent" now has an Uploaded column (#7)**

<table><tr>
<td><img src="https://raw.githubusercontent.com/keepid/keepid_client/5c39e14674bf281bc7143c7ce27153c92b20cd54/screenshots/05-documents-uploaded.png" height="380"></td>
<td><img src="https://raw.githubusercontent.com/keepid/keepid_client/5c39e14674bf281bc7143c7ce27153c92b20cd54/screenshots/m05-documents-uploaded.png" height="380"></td>
</tr></table>

**My Organization — mail summary defaults to current month; org-info phone also formatted (#8, #9)**

<table><tr>
<td><img src="https://raw.githubusercontent.com/keepid/keepid_client/5c39e14674bf281bc7143c7ce27153c92b20cd54/screenshots/06-mail-summary.png" height="380"></td>
<td><img src="https://raw.githubusercontent.com/keepid/keepid_client/5c39e14674bf281bc7143c7ce27153c92b20cd54/screenshots/m06-mail-summary.png" height="380"></td>
</tr></table>

> Screenshots are committed to the throwaway `assets/client-ui-tweaks-screens` branch (not merged into `server-migration`) and referenced by commit SHA.

## How to verify
- `npm start` (Vite, port 3000) against the dev backend on 7001; log in as demo-admin / demo-pass.
- Footer shows "© 2026". All Clients shows newest-first sort + Prev/[1]/Next. Profile and My Organization both show the org phone as `(+1) 215-555-0100`. Documents → Most Recent has an Uploaded column. My Organization → Mail Summary defaults to `05/01/2026 → 05/29/2026`.
- `npx eslint <changed .ts/.tsx>` and `npx stylelint src/static/styles/App.scss` both pass clean.

## Notes
- The darker selected-application-card styling (#4) is correct but not reachable through the current seeded preset-list flow (every "Start a new application" tile presets type/state/situation/person and jumps to review, bypassing the card-selection pages). Logged in the session journal as DEBT.
- While capturing screenshots, the My Organization "Organization Info" phone was found rendering raw while the Profile org section was formatted; fixed in a follow-up commit so #9 is consistent across both surfaces.
- No dedicated `code-reviewer` agent was available; a general-purpose review pass was run on the diff and its two warnings (login header in embedded mode — intended; mail-date UTC skew — fixed) were addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)