### PR TITLE
feat(scanner): continuous autofocus on the live camera track

### DIFF
--- a/src/components/Documents/Scanner/CameraViewfinder.tsx
+++ b/src/components/Documents/Scanner/CameraViewfinder.tsx
@@ -71,6 +71,21 @@ export default function CameraViewfinder({
         if (videoRef.current) {
           videoRef.current.srcObject = stream;
         }
+        // Request continuous autofocus on the live track. Many mobile devices
+        // default to fixed focus over getUserMedia, which is the root cause of
+        // blurry document scans. focusMode is an "advanced" MediaTrack
+        // constraint applied after the stream starts; it is unsupported on iOS
+        // Safari (which autofocuses anyway) so failures are non-fatal.
+        const [track] = stream.getVideoTracks();
+        const caps = (track?.getCapabilities?.() ?? {}) as Record<string, unknown>;
+        const focusModes = Array.isArray(caps.focusMode) ? (caps.focusMode as string[]) : [];
+        if (track && focusModes.includes('continuous')) {
+          track
+            .applyConstraints({ advanced: [{ focusMode: 'continuous' } as MediaTrackConstraintSet] })
+            .catch(() => {
+              /* device kept its default focus mode — acceptable */
+            });
+        }
       })
       .catch(handleStreamFailure);
 


### PR DESCRIPTION
## What
After the camera stream starts in `CameraViewfinder`, request the `focusMode: 'continuous'` advanced `MediaTrack` constraint when the device reports it as a capability.

## Why
Many mobile devices default to **fixed focus** over `getUserMedia`, which is a root cause of blurry document scans. Continuous autofocus keeps the document sharp as the user positions it.

## Safety
- Capability-gated: only applied when `track.getCapabilities().focusMode` includes `'continuous'`.
- Non-fatal: `applyConstraints` failures are caught and ignored — unsupported devices (e.g. iOS Safari, which autofocuses on its own) simply keep their default.

## How to verify
Requires a **physical mobile device** with a continuous-focus-capable camera (the constraint is a no-op on desktop webcams and can't be exercised in the preview). On such a device, the viewfinder should hold focus on the document instead of locking at a fixed plane.

## Note on screenshots
No visual/layout change — this is a runtime camera-capability constraint, so the viewfinder renders identically. Two-viewport screenshots would show no diff and the behavior can't be reproduced in the browser preview.

## Context
Recovered uncommitted work left floating in the working tree by a concurrent-agent run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)