### PR TITLE
Fix application PDF viewer rendering and edit clicks

### DIFF
--- a/src/components/Applications/ApplicationForm.tsx
+++ b/src/components/Applications/ApplicationForm.tsx
@@ -903,6 +903,8 @@ export default function ApplicationForm() {
             clientUsername={targetClientUsername}
             onSaveSuccess={handleSaveSuccess}
             postRequirements={builderStateRef.current?.postRequirements}
+            showPdfEditControls
+            pdfFormsReadOnly
             canEditAttachments={canEditAttachments}
           />
         )}

--- a/src/components/InteractiveForms/SignAndDownloadViewer.tsx
+++ b/src/components/InteractiveForms/SignAndDownloadViewer.tsx
@@ -111,7 +111,6 @@ const SignAndDownloadViewer = React.forwardRef<SignAndDownloadViewerHandle, Sign
   const [orgDocs, setOrgDocs] = useState<{ id: string; filename: string }[]>([]);
   const [selectedDocs, setSelectedDocs] = useState<Set<string>>(new Set());
   const [stagedDocs, setStagedDocs] = useState<Set<string>>(new Set());
-  const [orgDocsDialogOpen, setOrgDocsDialogOpen] = useState(false);
   const [isAppendingDocs, setIsAppendingDocs] = useState(false);
   const [packetStateLoaded, setPacketStateLoaded] = useState(false);
   const [packetSelectionHydrated, setPacketSelectionHydrated] = useState(false);
@@ -1062,9 +1061,6 @@ const SignAndDownloadViewer = React.forwardRef<SignAndDownloadViewerHandle, Sign
                 setSaveError(null);
                 setPdfEditSavedMessage(null);
                 setIsPdfEditMode(true);
-                if (canEditAttachments && orgDocs.length > 0) {
-                  setOrgDocsDialogOpen(true);
-                }
               }}
               className="tw-px-3 tw-py-2 tw-rounded-lg tw-text-sm tw-font-medium tw-text-white tw-bg-blue-600 hover:tw-bg-blue-700 tw-transition-colors"
             >
@@ -1304,91 +1300,6 @@ const SignAndDownloadViewer = React.forwardRef<SignAndDownloadViewerHandle, Sign
                 }`}
               >
                 {applying ? 'Embedding...' : 'Embed signature'}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {orgDocsDialogOpen && orgDocs.length > 0 && !effectivePdfFormsReadOnly && (
-        <div
-          className="tw-fixed tw-inset-0 tw-z-[1040] tw-flex tw-items-center tw-justify-center tw-p-4"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="keepid-org-docs-title"
-        >
-          <button
-            type="button"
-            className="tw-absolute tw-inset-0 tw-border-0 tw-bg-black/50 tw-p-0"
-            aria-label="Close attached documents"
-            onClick={() => setOrgDocsDialogOpen(false)}
-          />
-          <div className="tw-relative tw-z-10 tw-w-full tw-max-w-lg tw-rounded-lg tw-border tw-border-gray-200 tw-bg-white tw-shadow-xl">
-            <div className="tw-flex tw-items-center tw-justify-between tw-border-b tw-border-gray-200 tw-px-5 tw-py-4">
-              <h3 id="keepid-org-docs-title" className="tw-m-0 tw-text-base tw-font-semibold tw-text-gray-900">
-                Attached Organization Documents
-              </h3>
-              <button
-                type="button"
-                className="tw-border-0 tw-bg-transparent tw-p-1 tw-text-gray-500 hover:tw-text-gray-800"
-                aria-label="Close"
-                onClick={() => setOrgDocsDialogOpen(false)}
-              >
-                <XMarkIcon className="tw-h-5 tw-w-5" aria-hidden />
-              </button>
-            </div>
-            <div className="tw-px-5 tw-py-4">
-              {!allSigned ? (
-                <div className="tw-rounded-lg tw-bg-yellow-50 tw-p-3 tw-text-sm tw-text-yellow-800">
-                  Please complete all signatures before appending additional documents.
-                </div>
-              ) : (
-                <>
-                  <div className="tw-flex tw-flex-col tw-gap-2">
-                    {orgDocs.map((doc) => (
-                      <label key={doc.id} className="tw-flex tw-items-center tw-gap-2 tw-text-sm tw-text-gray-800">
-                        <input
-                          type="checkbox"
-                          checked={stagedDocs.has(doc.id)}
-                          disabled={isAppendingDocs || !packetPersistenceAvailable}
-                          onChange={() => toggleStagedDoc(doc.id)}
-                          className="tw-form-checkbox tw-h-4 tw-w-4 tw-rounded tw-border-gray-300 tw-text-blue-600 disabled:tw-opacity-50"
-                        />
-                        {doc.filename}
-                      </label>
-                    ))}
-                  </div>
-                  {!packetPersistenceAvailable && (
-                    <div className="tw-mt-3 tw-rounded tw-border tw-border-amber-200 tw-bg-amber-50 tw-p-2 tw-text-xs tw-text-amber-700">
-                      Packet persistence is currently unavailable for this application record.
-                    </div>
-                  )}
-                </>
-              )}
-            </div>
-            <div className="tw-flex tw-justify-end tw-gap-2 tw-border-t tw-border-gray-200 tw-bg-gray-50 tw-px-5 tw-py-4">
-              <button
-                type="button"
-                onClick={() => setOrgDocsDialogOpen(false)}
-                className="tw-rounded-lg tw-border tw-border-gray-300 tw-bg-white tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-gray-700 hover:tw-bg-gray-50"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={async () => {
-                  await applyOrgDocs();
-                  setOrgDocsDialogOpen(false);
-                }}
-                disabled={
-                  isAppendingDocs
-                  || !hasAttachmentSelectionChanges
-                  || !packetPersistenceAvailable
-                  || !allSigned
-                }
-                className="tw-rounded-lg tw-border-0 tw-bg-blue-600 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-white hover:tw-bg-blue-700 disabled:tw-bg-gray-400 disabled:tw-cursor-not-allowed"
-              >
-                {isAppendingDocs ? 'Applying changes...' : 'Apply Changes'}
               </button>
             </div>
           </div>

--- a/src/components/InteractiveForms/SignAndDownloadViewer.tsx
+++ b/src/components/InteractiveForms/SignAndDownloadViewer.tsx
@@ -111,6 +111,7 @@ const SignAndDownloadViewer = React.forwardRef<SignAndDownloadViewerHandle, Sign
   const [orgDocs, setOrgDocs] = useState<{ id: string; filename: string }[]>([]);
   const [selectedDocs, setSelectedDocs] = useState<Set<string>>(new Set());
   const [stagedDocs, setStagedDocs] = useState<Set<string>>(new Set());
+  const [orgDocsDialogOpen, setOrgDocsDialogOpen] = useState(false);
   const [isAppendingDocs, setIsAppendingDocs] = useState(false);
   const [packetStateLoaded, setPacketStateLoaded] = useState(false);
   const [packetSelectionHydrated, setPacketSelectionHydrated] = useState(false);
@@ -1061,6 +1062,9 @@ const SignAndDownloadViewer = React.forwardRef<SignAndDownloadViewerHandle, Sign
                 setSaveError(null);
                 setPdfEditSavedMessage(null);
                 setIsPdfEditMode(true);
+                if (canEditAttachments && orgDocs.length > 0) {
+                  setOrgDocsDialogOpen(true);
+                }
               }}
               className="tw-px-3 tw-py-2 tw-rounded-lg tw-text-sm tw-font-medium tw-text-white tw-bg-blue-600 hover:tw-bg-blue-700 tw-transition-colors"
             >
@@ -1300,6 +1304,91 @@ const SignAndDownloadViewer = React.forwardRef<SignAndDownloadViewerHandle, Sign
                 }`}
               >
                 {applying ? 'Embedding...' : 'Embed signature'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {orgDocsDialogOpen && orgDocs.length > 0 && !effectivePdfFormsReadOnly && (
+        <div
+          className="tw-fixed tw-inset-0 tw-z-[1040] tw-flex tw-items-center tw-justify-center tw-p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="keepid-org-docs-title"
+        >
+          <button
+            type="button"
+            className="tw-absolute tw-inset-0 tw-border-0 tw-bg-black/50 tw-p-0"
+            aria-label="Close attached documents"
+            onClick={() => setOrgDocsDialogOpen(false)}
+          />
+          <div className="tw-relative tw-z-10 tw-w-full tw-max-w-lg tw-rounded-lg tw-border tw-border-gray-200 tw-bg-white tw-shadow-xl">
+            <div className="tw-flex tw-items-center tw-justify-between tw-border-b tw-border-gray-200 tw-px-5 tw-py-4">
+              <h3 id="keepid-org-docs-title" className="tw-m-0 tw-text-base tw-font-semibold tw-text-gray-900">
+                Attached Organization Documents
+              </h3>
+              <button
+                type="button"
+                className="tw-border-0 tw-bg-transparent tw-p-1 tw-text-gray-500 hover:tw-text-gray-800"
+                aria-label="Close"
+                onClick={() => setOrgDocsDialogOpen(false)}
+              >
+                <XMarkIcon className="tw-h-5 tw-w-5" aria-hidden />
+              </button>
+            </div>
+            <div className="tw-px-5 tw-py-4">
+              {!allSigned ? (
+                <div className="tw-rounded-lg tw-bg-yellow-50 tw-p-3 tw-text-sm tw-text-yellow-800">
+                  Please complete all signatures before appending additional documents.
+                </div>
+              ) : (
+                <>
+                  <div className="tw-flex tw-flex-col tw-gap-2">
+                    {orgDocs.map((doc) => (
+                      <label key={doc.id} className="tw-flex tw-items-center tw-gap-2 tw-text-sm tw-text-gray-800">
+                        <input
+                          type="checkbox"
+                          checked={stagedDocs.has(doc.id)}
+                          disabled={isAppendingDocs || !packetPersistenceAvailable}
+                          onChange={() => toggleStagedDoc(doc.id)}
+                          className="tw-form-checkbox tw-h-4 tw-w-4 tw-rounded tw-border-gray-300 tw-text-blue-600 disabled:tw-opacity-50"
+                        />
+                        {doc.filename}
+                      </label>
+                    ))}
+                  </div>
+                  {!packetPersistenceAvailable && (
+                    <div className="tw-mt-3 tw-rounded tw-border tw-border-amber-200 tw-bg-amber-50 tw-p-2 tw-text-xs tw-text-amber-700">
+                      Packet persistence is currently unavailable for this application record.
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+            <div className="tw-flex tw-justify-end tw-gap-2 tw-border-t tw-border-gray-200 tw-bg-gray-50 tw-px-5 tw-py-4">
+              <button
+                type="button"
+                onClick={() => setOrgDocsDialogOpen(false)}
+                className="tw-rounded-lg tw-border tw-border-gray-300 tw-bg-white tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-gray-700 hover:tw-bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={async () => {
+                  await applyOrgDocs();
+                  setOrgDocsDialogOpen(false);
+                }}
+                disabled={
+                  isAppendingDocs
+                  || !hasAttachmentSelectionChanges
+                  || !packetPersistenceAvailable
+                  || !allSigned
+                }
+                className="tw-rounded-lg tw-border-0 tw-bg-blue-600 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-white hover:tw-bg-blue-700 disabled:tw-bg-gray-400 disabled:tw-cursor-not-allowed"
+              >
+                {isAppendingDocs ? 'Applying changes...' : 'Apply Changes'}
               </button>
             </div>
           </div>

--- a/src/components/InteractiveForms/SignAndDownloadViewer.tsx
+++ b/src/components/InteractiveForms/SignAndDownloadViewer.tsx
@@ -187,8 +187,10 @@ const SignAndDownloadViewer = React.forwardRef<SignAndDownloadViewerHandle, Sign
   const pageDevicePixelRatio = typeof window === 'undefined'
     ? 2
     : Math.max(window.devicePixelRatio || 1, 2);
+  const pdfWidgetsEditable = !pdfFormsReadOnly || (showPdfEditControls && isPdfEditMode);
+  const effectivePdfFormsReadOnly = !pdfWidgetsEditable;
   /** pdf.js HTML widgets whenever the document is editable; flushes via saveDocument on save/download/sign. */
-  const usePdfJsFormWidgets = !pdfFormsReadOnly;
+  const usePdfJsFormWidgets = pdfWidgetsEditable;
 
   const signedCount = embeddedBoxes.size;
   const allSigned = signaturePlacements.length === 0 || signedCount === signaturePlacements.length;
@@ -672,7 +674,7 @@ const SignAndDownloadViewer = React.forwardRef<SignAndDownloadViewerHandle, Sign
   }, [combinedViewerDocs, pageNum]);
   const isViewingMainPdf = currentViewerPageMeta.doc.kind === 'main';
   const canEditCurrentAttachment =
-    currentViewerPageMeta.doc.kind === 'attachment' && canEditAttachments && !pdfFormsReadOnly;
+    currentViewerPageMeta.doc.kind === 'attachment' && canEditAttachments && !effectivePdfFormsReadOnly;
 
   const getMainPdfBytes = useCallback(async (): Promise<Uint8Array> => {
     const shouldUseSaveDocument = usePdfJsFormWidgets && !!pdfDocRef.current?.saveDocument && pageNum <= numPages;
@@ -856,7 +858,7 @@ const SignAndDownloadViewer = React.forwardRef<SignAndDownloadViewerHandle, Sign
     setSaving(true);
     try {
       if (currentViewerPageMeta.doc.kind === 'attachment') {
-        if (!canEditAttachments || pdfFormsReadOnly) {
+        if (!canEditAttachments || effectivePdfFormsReadOnly) {
           throw new Error('Attachment editing is not available in this mode.');
         }
         const sourceFileId = currentViewerPageMeta.doc.sourceFileId || currentViewerPageMeta.doc.id;
@@ -895,7 +897,7 @@ const SignAndDownloadViewer = React.forwardRef<SignAndDownloadViewerHandle, Sign
     getCurrentAttachmentPdfBlob,
     getCurrentPdfBlob,
     onSaveSuccess,
-    pdfFormsReadOnly,
+    effectivePdfFormsReadOnly,
   ]);
 
   const handleSavePdfEdits = useCallback(async (): Promise<boolean> => {
@@ -904,7 +906,7 @@ const SignAndDownloadViewer = React.forwardRef<SignAndDownloadViewerHandle, Sign
     setSavingPdfEdits(true);
     try {
       if (currentViewerPageMeta.doc.kind === 'attachment') {
-        if (!canEditAttachments || pdfFormsReadOnly) {
+        if (!canEditAttachments || effectivePdfFormsReadOnly) {
           throw new Error('Attachment editing is not available in this mode.');
         }
         const sourceFileId = currentViewerPageMeta.doc.sourceFileId || currentViewerPageMeta.doc.id;
@@ -955,7 +957,7 @@ const SignAndDownloadViewer = React.forwardRef<SignAndDownloadViewerHandle, Sign
     getCurrentAttachmentPdfBlob,
     getCurrentPdfBlob,
     livePdfUrl,
-    pdfFormsReadOnly,
+    effectivePdfFormsReadOnly,
   ]);
 
   const handleCancelPdfEdits = useCallback(() => {
@@ -1033,7 +1035,7 @@ const SignAndDownloadViewer = React.forwardRef<SignAndDownloadViewerHandle, Sign
   return (
     <div className={`tw-flex tw-flex-col tw-gap-8 tw-items-start tw-w-full tw-mx-auto ${FRAME_MAX_WIDTH_CLASS}`}>
       <div
-        className={`keepid-pdf-preview ${pdfFormsReadOnly ? 'keepid-pdf-edit-locked' : ''} ${usePdfJsFormWidgets ? 'keepid-pdf-form-widgets-active' : ''} tw-space-y-4 tw-w-full`}
+        className={`keepid-pdf-preview ${effectivePdfFormsReadOnly ? 'keepid-pdf-edit-locked' : ''} ${usePdfJsFormWidgets ? 'keepid-pdf-form-widgets-active' : ''} tw-space-y-4 tw-w-full`}
       >
       {allSigned && signaturePlacements.length > 0 && (
         <div className="tw-flex tw-items-center tw-justify-between tw-rounded-lg tw-border tw-border-green-200 tw-bg-green-50 tw-px-4 tw-py-2.5">
@@ -1130,7 +1132,7 @@ const SignAndDownloadViewer = React.forwardRef<SignAndDownloadViewerHandle, Sign
                 Attached pages appended: {totalAttachedPages}
               </div>
             )}
-            {!pdfFormsReadOnly && !isViewingMainPdf && !canEditCurrentAttachment && (
+            {!effectivePdfFormsReadOnly && !isViewingMainPdf && !canEditCurrentAttachment && (
               <div className="tw-px-3 tw-pb-2 tw-text-xs tw-text-amber-700 tw-font-medium">
                 Attachment pages are view-only. Edit fields on the main application pages.
               </div>
@@ -1148,7 +1150,7 @@ const SignAndDownloadViewer = React.forwardRef<SignAndDownloadViewerHandle, Sign
                   renderForms={usePdfJsFormWidgets && (isViewingMainPdf || canEditCurrentAttachment)}
                 />
               </div>
-              {pdfFormsReadOnly && (
+              {effectivePdfFormsReadOnly && (
                 <div
                   className="tw-absolute tw-inset-0 tw-z-30 tw-cursor-not-allowed"
                   title="PDF is read-only."
@@ -1313,7 +1315,7 @@ const SignAndDownloadViewer = React.forwardRef<SignAndDownloadViewerHandle, Sign
         </div>
       )}
 
-      {orgDocs.length > 0 && !pdfFormsReadOnly && (!showPdfEditControls || isPdfEditMode) && (
+      {orgDocs.length > 0 && !effectivePdfFormsReadOnly && (!showPdfEditControls || isPdfEditMode) && (
         <div className="tw-rounded-lg tw-border tw-border-gray-200 tw-bg-gray-50 tw-px-4 tw-py-3">
           <h4 className="tw-text-sm tw-font-bold tw-text-gray-900 tw-mb-2">Attached Organization Documents</h4>
           {!allSigned ? (

--- a/src/components/InteractiveForms/sign-and-download-viewer.css
+++ b/src/components/InteractiveForms/sign-and-download-viewer.css
@@ -8,8 +8,7 @@
   width: 100% !important;
   height: auto !important;
   display: block;
-  image-rendering: -webkit-optimize-contrast;
-  image-rendering: crisp-edges;
+  image-rendering: auto;
 }
 
 .keepid-pdf-preview .react-pdf__Page__textContent,
@@ -18,6 +17,23 @@
   inset: 0;
   width: 100% !important;
   height: 100% !important;
+}
+
+.keepid-pdf-preview .react-pdf__Page__textContent {
+  z-index: 1;
+}
+
+.keepid-pdf-preview .react-pdf__Page__annotations {
+  z-index: 2;
+}
+
+.keepid-pdf-preview.keepid-pdf-form-widgets-active .react-pdf__Page__textContent {
+  pointer-events: none;
+}
+
+.keepid-pdf-preview.keepid-pdf-form-widgets-active .react-pdf__Page__annotations,
+.keepid-pdf-preview.keepid-pdf-form-widgets-active .annotationLayer :is(input, textarea, select, button) {
+  pointer-events: auto;
 }
 
 .keepid-pdf-preview.keepid-pdf-edit-locked .react-pdf__Page__annotations {


### PR DESCRIPTION
## Summary
- Remove crisp-edge image scaling from the application PDF canvas so rendered forms appear smoother.
- Ensure the PDF annotation layer sits above the text layer and receives pointer events when form widgets are active, so Edit PDF fields can be selected and changed.
- Show the PDF edit controls on the completed-application screen and make the viewer's internal edit mode actually unlock PDF widgets and attachment editing.

## Verification
- `npm run build` passes.
- `npm run lint:scss` fails on pre-existing `src/static/styles/QuickAccess.scss` stylelint violations unrelated to this CSS file.
- Local smoke: `http://localhost:3000`, `http://localhost:5173`, and `http://localhost:7001/actuator/health` respond.

## Screenshots
- Not captured; styling/interaction change is in the PDF viewer layer.

## Notes
- Branch is based on `server-migration` as requested.
- Existing saved applications created before the server-side preserving-fill fix may already be flattened; create a fresh application to verify editable fields after completion.
