### PR TITLE
Redirect globally when sessions expire

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ import ForgotPassword from './components/UserAuthentication/ForgotPassword';
 import ResetPassword from './components/UserAuthentication/ResetPassword';
 import getServerURL from './serverOverride';
 import Role from './static/Role';
+import { installSessionExpiryInterceptor, SESSION_EXPIRED_EVENT } from './utils/sessionExpiry';
 
 window.onload = () => {
   ReactGA.initialize('AW-391118279');
@@ -136,6 +137,7 @@ class App extends React.Component<{}, State, {}> {
   }
 
   componentDidMount() {
+    installSessionExpiryInterceptor();
     this.refreshAuthFromServer();
     // Listen for in-app profile updates (e.g. name change in Account
     // Information). The handler hits /authenticate again so App.state.name
@@ -144,14 +146,25 @@ class App extends React.Component<{}, State, {}> {
     // EssentialAccountSection after a successful /update-user-profile
     // that touched firstName / lastName.
     window.addEventListener('keepid:profile-updated', this.handleProfileUpdated);
+    window.addEventListener(SESSION_EXPIRED_EVENT, this.handleSessionExpired);
   }
 
   componentWillUnmount() {
     window.removeEventListener('keepid:profile-updated', this.handleProfileUpdated);
+    window.removeEventListener(SESSION_EXPIRED_EVENT, this.handleSessionExpired);
   }
 
   handleProfileUpdated = () => {
     this.refreshAuthFromServer();
+  };
+
+  handleSessionExpired = () => {
+    if (this.state.role === Role.LoggedOut) return;
+    this.logOut();
+    this.setAutoLogout(true);
+    if (window.location.pathname !== '/login') {
+      window.location.assign('/login');
+    }
   };
 
   refreshAuthFromServer = () => {
@@ -212,7 +225,7 @@ class App extends React.Component<{}, State, {}> {
             this.logIn(role(), username, organization, `${firstName} ${lastName}`);
           }
         } else if (this.state.role !== Role.LoggedOut) {
-          this.logOut();
+          this.handleSessionExpired();
         } else {
           this.logOut();
         }

--- a/src/utils/sessionExpiry.ts
+++ b/src/utils/sessionExpiry.ts
@@ -1,0 +1,75 @@
+import getServerURL from '../serverOverride';
+
+export const SESSION_EXPIRED_EVENT = 'keepid:session-expired';
+
+let installed = false;
+
+const publicAuthPaths = new Set([
+  '/login',
+  '/logout',
+  '/authenticate',
+  '/get-session-user',
+  '/forgot-password',
+  '/reset-password',
+  '/username-exists',
+  '/organization-signup',
+  '/googleLoginRequest',
+  '/googleLoginResponse',
+  '/microsoftLoginRequest',
+  '/microsoftLoginResponse',
+]);
+
+function requestPath(input: RequestInfo | URL): string | null {
+  const rawUrl = typeof input === 'string' || input instanceof URL ? input.toString() : input.url;
+  try {
+    const parsed = new URL(rawUrl, window.location.origin);
+    const server = new URL(getServerURL());
+    if (parsed.origin !== server.origin) return null;
+    return parsed.pathname;
+  } catch {
+    return null;
+  }
+}
+
+function shouldWatchRequest(input: RequestInfo | URL): boolean {
+  const path = requestPath(input);
+  if (!path) return false;
+  return !publicAuthPaths.has(path);
+}
+
+function dispatchSessionExpired(): void {
+  window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT));
+}
+
+async function inspectAuthFailure(input: RequestInfo | URL, response: Response): Promise<void> {
+  if (!shouldWatchRequest(input)) return;
+
+  if (response.status === 401 || response.status === 403) {
+    dispatchSessionExpired();
+    return;
+  }
+
+  const contentType = response.headers.get('content-type') || '';
+  if (!contentType.includes('application/json')) return;
+
+  try {
+    const body = await response.clone().json();
+    if (body?.status === 'AUTH_FAILURE') {
+      dispatchSessionExpired();
+    }
+  } catch {
+    // Binary downloads and non-JSON responses are not auth signals.
+  }
+}
+
+export function installSessionExpiryInterceptor(): void {
+  if (installed || typeof window === 'undefined' || typeof window.fetch !== 'function') return;
+  installed = true;
+
+  const originalFetch = window.fetch.bind(window);
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const response = await originalFetch(input, init);
+    inspectAuthFailure(input, response).catch(() => undefined);
+    return response;
+  };
+}


### PR DESCRIPTION
## Summary
- Add a global fetch interceptor for server API responses that indicate an expired session.
- Dispatch a top-level session-expired event on `401`, `403`, or JSON `AUTH_FAILURE` from authenticated endpoints.
- Clear client auth state, preserve the auto-logout notice, and redirect to `/login` immediately instead of leaving stale pages until later navigation.

## Verification
- `npm run build`
- `npx eslint src/App.tsx src/utils/sessionExpiry.ts`
- `npm run lint:ts` not fully clean because of existing unrelated lint errors in `MailModal.tsx`, `Header.tsx`, `InstallPromptContainer.tsx`, and `SignAndDownloadViewer.tsx`.

## Screenshots
- Not applicable; redirect/session behavior change.

## Notes
- Public auth routes like login, reset password, forgot password, and OAuth request/response endpoints are excluded so normal auth failures there do not trigger a global session-expired redirect.
