### PR TITLE
[codex] Fix OAuth redirect URI construction

### DIFF
--- a/src/components/UserAuthentication/GoogleLoginButton.tsx
+++ b/src/components/UserAuthentication/GoogleLoginButton.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 
 import getServerURL from '../../serverOverride';
+import { buildOAuthRedirectUri } from './oauthRedirect';
 
 const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
 
@@ -16,16 +17,7 @@ export default function GoogleLoginButton({ handleGoogleLoginSuccess, handleGoog
   }, []);
 
   const handleClick = () => {
-    // Build an ABSOLUTE redirect URI. getServerURL() may return a relative
-    // path (e.g. "/api" in the Cloud Run prod build); Google rejects
-    // relative redirect_uri values. Prefixing with window.location.origin
-    // produces the full URL that the browser will navigate to after auth,
-    // which is also what must be registered in the Google OAuth client
-    // console AND in the server's keepid.oauth.allowed-redirect-uris
-    // allowlist. window.location.origin makes this self-correcting across
-    // every host the FE might be served from (keep.id, the Cloud Run
-    // preview URL, localhost, future custom domains).
-    const redirectUri = `${window.location.origin}${getServerURL()}/googleLoginResponse`;
+    const redirectUri = buildOAuthRedirectUri(getServerURL(), '/googleLoginResponse');
     const originUri = window.location.origin;
 
     fetch(`${getServerURL()}/googleLoginRequest`, {

--- a/src/components/UserAuthentication/MicrosoftLoginButton.tsx
+++ b/src/components/UserAuthentication/MicrosoftLoginButton.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 
 import getServerURL from '../../serverOverride';
+import { buildOAuthRedirectUri } from './oauthRedirect';
 
 const clientId = import.meta.env.VITE_MICROSOFT_CLIENT_ID;
 const tenantId = import.meta.env.VITE_MICROSOFT_TENANT_ID || 'organizations';
@@ -22,10 +23,7 @@ export default function MicrosoftLoginButton({ handleMicrosoftLoginSuccess, hand
       return;
     }
 
-    // Absolute URLs from the live origin — see GoogleLoginButton for the
-    // detailed rationale. Build-mode-based hardcoded origins broke as
-    // soon as the FE was deployed at a non-canonical URL.
-    const redirectUri = `${window.location.origin}${getServerURL()}/microsoftLoginResponse`;
+    const redirectUri = buildOAuthRedirectUri(getServerURL(), '/microsoftLoginResponse');
     const originUri = window.location.origin;
 
     fetch(`${getServerURL()}/microsoftLoginRequest`, {

--- a/src/components/UserAuthentication/oauthRedirect.test.ts
+++ b/src/components/UserAuthentication/oauthRedirect.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildOAuthRedirectUri } from './oauthRedirect';
+
+describe('buildOAuthRedirectUri', () => {
+  it('uses the server origin when getServerURL returns an absolute URL', () => {
+    expect(
+      buildOAuthRedirectUri(
+        'http://localhost:7001',
+        '/googleLoginResponse',
+        'http://localhost:3000',
+      ),
+    ).toBe('http://localhost:7001/googleLoginResponse');
+  });
+
+  it('uses the browser origin when getServerURL returns a relative path', () => {
+    expect(
+      buildOAuthRedirectUri(
+        '/api',
+        '/microsoftLoginResponse',
+        'https://app.keep.id',
+      ),
+    ).toBe('https://app.keep.id/api/microsoftLoginResponse');
+  });
+
+  it('does not duplicate slashes around the callback path', () => {
+    expect(
+      buildOAuthRedirectUri(
+        'https://server.keep.id/',
+        'googleLoginResponse',
+        'https://keep.id',
+      ),
+    ).toBe('https://server.keep.id/googleLoginResponse');
+  });
+});

--- a/src/components/UserAuthentication/oauthRedirect.ts
+++ b/src/components/UserAuthentication/oauthRedirect.ts
@@ -1,0 +1,19 @@
+export function buildOAuthRedirectUri(
+  serverUrl: string,
+  callbackPath: string,
+  browserOrigin: string = window.location.origin,
+) {
+  const normalizedCallbackPath = callbackPath.startsWith('/')
+    ? callbackPath
+    : `/${callbackPath}`;
+
+  if (/^https?:\/\//i.test(serverUrl)) {
+    return new URL(normalizedCallbackPath, serverUrl).toString();
+  }
+
+  const normalizedServerPath = serverUrl.endsWith('/')
+    ? serverUrl.slice(0, -1)
+    : serverUrl;
+
+  return `${browserOrigin}${normalizedServerPath}${normalizedCallbackPath}`;
+}


### PR DESCRIPTION
## Summary
- Build Google and Microsoft OAuth callback URLs with an origin-aware helper.
- Avoid concatenating `window.location.origin` with an already-absolute API URL.
- Add focused coverage for absolute and relative API base URLs.

## Verification
- `npx vitest run src/components/UserAuthentication/oauthRedirect.test.ts`
- `npx eslint src/components/UserAuthentication/GoogleLoginButton.tsx src/components/UserAuthentication/MicrosoftLoginButton.tsx src/components/UserAuthentication/oauthRedirect.ts src/components/UserAuthentication/oauthRedirect.test.ts --ext .ts,.tsx`
- `npm run build`
- `npm run lint:ts` fails due to pre-existing unrelated lint errors in `MailModal.tsx`, `Header.tsx`, `InstallPromptContainer.tsx`, and `SignAndDownloadViewer.tsx`.

## Screenshots
- Not applicable.

## Notes
- Root cause: the OAuth buttons built callback URLs like `http://localhost:3000http://localhost:7001/googleLoginResponse` when `getServerURL()` returned an absolute URL, causing the server to reject the request before redirecting to the provider.