### PR TITLE
Remove stale session-expired copy

### DIFF
--- a/src/components/LandingPages/WorkerLanding.tsx
+++ b/src/components/LandingPages/WorkerLanding.tsx
@@ -199,7 +199,7 @@ const WorkerLanding: React.FC<Props> = ({ username, name, organization, role, lo
         const { people, status } = responseJSON;
 
         if (status === 'AUTH_FAILURE') {
-          alert.show('Your session expired. Please sign in again.');
+          alert.show('Please sign in again to continue.');
           logOut();
           return;
         }

--- a/src/components/SignUp/EnrollClient.tsx
+++ b/src/components/SignUp/EnrollClient.tsx
@@ -134,7 +134,7 @@ export default function EnrollClientPage(): JSX.Element {
       } else if (response.status === 'CLIENT_ENROLL_CLIENT') {
         alert.error('Only workers, admins, or directors can enroll clients.');
       } else if (response.status === 'SESSION_TOKEN_FAILURE') {
-        alert.error('Your session has expired. Please log in again.');
+        alert.error('Please sign in again to continue.');
       } else {
         alert.error(`Enrollment failed: ${response.status}`);
       }

--- a/src/components/SignUp/EnrollWorker.tsx
+++ b/src/components/SignUp/EnrollWorker.tsx
@@ -125,7 +125,7 @@ export default function EnrollWorkerPage(): JSX.Element {
       } else if (response.status === 'EMAIL_ALREADY_EXISTS') {
         alert.error('A user with this email already exists.');
       } else if (response.status === 'SESSION_TOKEN_FAILURE') {
-        alert.error('Your session has expired. Please log in again.');
+        alert.error('Please sign in again to continue.');
       } else if (response.status === 'INVALID_PARAMETER') {
         alert.error('Invalid role selected. Please choose Worker or Admin.');
       } else {


### PR DESCRIPTION
## Summary
- Replace stale “session expired” copy in worker landing and enrollment auth failures with neutral sign-in guidance.
- Keep logout behavior for auth failures, but stop implying the removed inactivity timer fired.

## Verification
- npm run build
- ./node_modules/.bin/eslint src/components/LandingPages/WorkerLanding.tsx src/components/SignUp/EnrollWorker.tsx src/components/SignUp/EnrollClient.tsx --ext .ts,.tsx
- npm run lint:ts (fails: unrelated existing lint issues in MailModal.tsx, Header.tsx, InstallPromptContainer.tsx, SignAndDownloadViewer.tsx, and warnings elsewhere)
- npm run lint:scss (fails: unrelated existing QuickAccess.scss stylelint issues)

## Screenshots
- N/A

## Notes
- npm ci warned that the current Node v25.9.0 differs from package engine 22.14.0 and reported existing audit vulnerabilities.
