### PR TITLE
Fix communications panel scrolling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -654,7 +654,11 @@ class App extends React.Component<{}, State, {}> {
               </Route>
             </Switch>
           </div>
-          <Footer />
+          <Route
+            render={({ location }) => (
+              location.pathname.startsWith('/communications') ? null : <Footer />
+            )}
+          />
         </div>
         </UserContext.Provider>
       </Router>

--- a/src/components/Communications/communications.css
+++ b/src/components/Communications/communications.css
@@ -8,8 +8,9 @@
 .communications-shell {
   display: grid;
   grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
-  height: calc(100vh - 80px);
-  min-height: 680px;
+  height: calc(100dvh - 80px);
+  min-height: 0;
+  overflow: hidden;
   background: #f7fafc;
   color: #1f2933;
 }
@@ -18,6 +19,8 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
+  min-height: 0;
+  overflow: hidden;
   border-right: 1px solid #d9e2ec;
   background: #fff;
 }
@@ -67,6 +70,7 @@
 }
 
 .contact-scroll {
+  flex: 1 1 auto;
   padding: 0 10px 18px;
 }
 
@@ -129,6 +133,8 @@
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
   min-width: 0;
+  min-height: 0;
+  overflow: hidden;
   background: #f7fafc;
 }
 


### PR DESCRIPTION
## Summary
- Hide the global site footer on communications routes so the communications tab behaves like an app panel.
- Make the communications shell height-bound with hidden outer overflow.
- Make the client list and chat panel own their internal scroll regions with `min-height: 0` and flex/grid overflow fixes.

## Root Cause
After the server began returning the full client list, the communications page was still participating in the normal page flow with the global footer underneath it. The left client list did not have a strict internal scroll container, so the page could scroll down into the footer while the contact rows continued past it.

## Verification
- `npm run build`
- `npx eslint src/App.tsx src/components/Communications/CallsPage.tsx --ext .ts,.tsx`

## Notes
- I accidentally pointed ESLint at the CSS file first; that failed because this repo's ESLint command parses TS/TSX, not CSS. The corrected targeted lint passed.
