### PR TITLE
Remove communications page overscroll

### DIFF
--- a/src/components/Communications/communications.css
+++ b/src/components/Communications/communications.css
@@ -5,10 +5,21 @@
   color: #1f2933;
 }
 
+body:has(.communications-shell),
+.App:has(.communications-shell) {
+  height: 100dvh;
+  overflow: hidden;
+}
+
+.app:has(.communications-shell) {
+  padding-bottom: 0 !important;
+  overflow: hidden;
+}
+
 .communications-shell {
   display: grid;
   grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
-  height: calc(100dvh - 80px);
+  height: calc(100dvh - 64px);
   min-height: 0;
   overflow: hidden;
   background: #f7fafc;


### PR DESCRIPTION
## Summary
- Prevent page-level scrolling on communications routes when the communications shell is mounted.
- Change the call modal from a fake active-call state to a pre-call modal with a real `tel:` Call action and empty notes.
- Load phone-only message boards for unmatched caller conversations.
- Add an admin-only Twilio Message Backfill card to My Organization.
- Remove leftover app wrapper bottom padding for communications.
- Adjust the communications shell height to match the sticky header so the composer sits at the bottom of the viewport without a blank ledge below it.

## Root Cause
The communications footer fix removed the global footer, but the root app wrapper still had page-level bottom padding and the body could still scroll. With the full client list loaded, that left a visible blank scroll area under the communications panel.

## Twilio Backfill UX
- Admins can pick a date range, optionally override the Twilio number, and cap the scan size.
- `Dry Run` shows scanned, matched, unmatched, existing, inserted, updated, and skipped counts.
- `Import Messages` stays disabled until a successful dry run has completed for the current inputs.
- The server dedupes by Twilio message SID, so rerunning the same import should not duplicate communications.

## Verification
- `npm run build`
- `npx eslint src/App.tsx src/components/Communications/CallsPage.tsx --ext .ts,.tsx`
- `npx eslint src/components/Communications/CallsPage.tsx src/components/Communications/communicationsApi.ts --ext .ts,.tsx`
- `npx eslint src/components/AccountSettings/MyOrganization.tsx --ext .tsx`

## Notes
- `npm run lint:ts` still fails on pre-existing unrelated lint errors in `MailModal.tsx`, `InstallPromptContainer.tsx`, and `SignAndDownloadViewer.tsx`.