### PR TITLE
Recover communications call and backfill UI

### DIFF
--- a/src/components/AccountSettings/MyOrganization.tsx
+++ b/src/components/AccountSettings/MyOrganization.tsx
@@ -144,6 +144,20 @@ interface OrganizationReportResponse {
   reportText?: string;
 }
 
+interface TwilioBackfillResponse {
+  status: string;
+  message?: string;
+  dryRun: boolean;
+  phoneNumber?: string;
+  scannedMessages: number;
+  matchedMessages: number;
+  unmatchedMessages: number;
+  insertedMessages: number;
+  existingMessages: number;
+  updatedMessages: number;
+  skippedMessages: number;
+}
+
 const MyOrganization: React.FC<Props> = ({ name, organization, role, alert }) => {
   const [orgInfo, setOrgInfo] = useState<OrgInfo>({
     name: '',
@@ -179,6 +193,17 @@ const MyOrganization: React.FC<Props> = ({ name, organization, role, alert }) =>
   const [reportShowClientNames, setReportShowClientNames] = useState(false);
   const [reportText, setReportText] = useState('');
   const [isGeneratingReport, setIsGeneratingReport] = useState(false);
+  const [backfillDateFrom, setBackfillDateFrom] = useState(() => {
+    const d = new Date();
+    d.setDate(d.getDate() - 30);
+    return toLocalISODate(d);
+  });
+  const [backfillDateTo, setBackfillDateTo] = useState(() => toLocalISODate(new Date()));
+  const [backfillPhoneNumber, setBackfillPhoneNumber] = useState('');
+  const [backfillMaxMessages, setBackfillMaxMessages] = useState('2000');
+  const [backfillResult, setBackfillResult] = useState<TwilioBackfillResponse | null>(null);
+  const [lastSuccessfulDryRunKey, setLastSuccessfulDryRunKey] = useState('');
+  const [isBackfilling, setIsBackfilling] = useState(false);
 
   const [orgDocs, setOrgDocs] = useState<OrgDocument[]>([]);
   const [isLoadingDocs, setIsLoadingDocs] = useState(false);
@@ -196,6 +221,15 @@ const MyOrganization: React.FC<Props> = ({ name, organization, role, alert }) =>
 
   const canManageMembers = role === Role.Director || role === Role.Admin;
   const canEditOrganization = role === Role.Admin;
+  const backfillRequestKey = useMemo(
+    () => JSON.stringify({
+      fromDate: backfillDateFrom,
+      toDate: backfillDateTo,
+      phoneNumber: backfillPhoneNumber.trim(),
+      maxMessages: Number(backfillMaxMessages) || null,
+    }),
+    [backfillDateFrom, backfillDateTo, backfillPhoneNumber, backfillMaxMessages],
+  );
 
   const adminMembers = useMemo(
     () => workers.filter((worker) => worker.privilegeLevel === 'Admin'),
@@ -423,6 +457,38 @@ const MyOrganization: React.FC<Props> = ({ name, organization, role, alert }) =>
       alert.show('Report copied.');
     } catch {
       alert.show('Unable to copy report automatically. Select the text and copy it manually.', { type: 'error' });
+    }
+  };
+
+  const handleTwilioBackfill = async (dryRun: boolean) => {
+    setIsBackfilling(true);
+    try {
+      const res = await fetch(`${getServerURL()}/api/admin/communications/backfill/twilio`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          fromDate: backfillDateFrom,
+          toDate: backfillDateTo,
+          dryRun,
+          phoneNumber: backfillPhoneNumber.trim() || undefined,
+          maxMessages: Number(backfillMaxMessages) || undefined,
+        }),
+      });
+      const data = await res.json() as TwilioBackfillResponse;
+      setBackfillResult(data);
+      if (data.status === 'SUCCESS') {
+        if (dryRun) {
+          setLastSuccessfulDryRunKey(backfillRequestKey);
+        }
+        alert.show(dryRun ? 'Twilio dry run complete.' : 'Twilio messages imported.');
+      } else {
+        alert.show(`Twilio backfill failed: ${data.message || data.status}`, { type: 'error' });
+      }
+    } catch (error) {
+      alert.show(`Twilio backfill failed: ${error}`, { type: 'error' });
+    } finally {
+      setIsBackfilling(false);
     }
   };
 
@@ -826,6 +892,131 @@ const MyOrganization: React.FC<Props> = ({ name, organization, role, alert }) =>
     </div>
   );
 
+  const renderTwilioBackfillContent = () => {
+    const canImportBackfill = lastSuccessfulDryRunKey === backfillRequestKey;
+    const resultRows = backfillResult
+      ? [
+        ['Scanned', backfillResult.scannedMessages],
+        ['Matched to clients', backfillResult.matchedMessages],
+        ['Unmatched', backfillResult.unmatchedMessages],
+        ['Inserted', backfillResult.insertedMessages],
+        ['Already existed', backfillResult.existingMessages],
+        ['Status updated', backfillResult.updatedMessages],
+        ['Skipped', backfillResult.skippedMessages],
+      ]
+      : [];
+
+    return (
+      <div className="tw-space-y-4">
+        <div className="tw-grid tw-grid-cols-1 md:tw-grid-cols-[1fr_auto_1fr] tw-gap-3 md:tw-items-end">
+          <div>
+            <label htmlFor="twilioBackfillDateFrom" className="tw-block tw-text-sm tw-font-medium tw-text-gray-700 tw-mb-1">
+              Start date
+            </label>
+            <input
+              id="twilioBackfillDateFrom"
+              type="date"
+              className="form-control form-purple"
+              value={backfillDateFrom}
+              onChange={(e) => setBackfillDateFrom(e.target.value)}
+            />
+          </div>
+          <span className="tw-hidden md:tw-block tw-text-gray-500 tw-pb-2">to</span>
+          <div>
+            <label htmlFor="twilioBackfillDateTo" className="tw-block tw-text-sm tw-font-medium tw-text-gray-700 tw-mb-1">
+              End date
+            </label>
+            <input
+              id="twilioBackfillDateTo"
+              type="date"
+              className="form-control form-purple"
+              value={backfillDateTo}
+              onChange={(e) => setBackfillDateTo(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div className="tw-grid tw-grid-cols-1 md:tw-grid-cols-[2fr_1fr] tw-gap-3">
+          <div>
+            <label htmlFor="twilioBackfillPhoneNumber" className="tw-block tw-text-sm tw-font-medium tw-text-gray-700 tw-mb-1">
+              Twilio number
+            </label>
+            <input
+              id="twilioBackfillPhoneNumber"
+              type="tel"
+              className="form-control form-purple"
+              value={backfillPhoneNumber}
+              onChange={(e) => setBackfillPhoneNumber(e.target.value)}
+              placeholder="Use configured hotline"
+            />
+          </div>
+          <div>
+            <label htmlFor="twilioBackfillMaxMessages" className="tw-block tw-text-sm tw-font-medium tw-text-gray-700 tw-mb-1">
+              Max messages
+            </label>
+            <input
+              id="twilioBackfillMaxMessages"
+              type="number"
+              min="1"
+              max="10000"
+              className="form-control form-purple"
+              value={backfillMaxMessages}
+              onChange={(e) => setBackfillMaxMessages(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div className="tw-flex tw-flex-col sm:tw-flex-row sm:tw-items-center sm:tw-justify-between tw-gap-3">
+          <p className="tw-text-sm tw-text-gray-500 tw-mb-0">
+            Dry run first to see what Twilio will import. Existing messages are matched by Twilio SID and skipped.
+          </p>
+          <div className="tw-flex tw-gap-2">
+            <button
+              type="button"
+              className="btn btn-outline-dark"
+              onClick={() => handleTwilioBackfill(true)}
+              disabled={isBackfilling}
+            >
+              {isBackfilling ? 'Running...' : 'Dry Run'}
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={() => handleTwilioBackfill(false)}
+              disabled={isBackfilling || !canImportBackfill}
+            >
+              Import Messages
+            </button>
+          </div>
+        </div>
+
+        {backfillResult && (
+          <div className="tw-rounded tw-border tw-border-gray-200 tw-bg-gray-50 tw-p-3">
+            <div className="tw-flex tw-flex-col sm:tw-flex-row sm:tw-items-center sm:tw-justify-between tw-gap-1 tw-mb-3">
+              <div className="tw-font-semibold tw-text-gray-900">
+                {backfillResult.dryRun ? 'Dry run result' : 'Import result'}
+              </div>
+              <div className="tw-text-sm tw-text-gray-500">
+                {backfillResult.phoneNumber ? `Number: ${formatPhoneForDisplay(backfillResult.phoneNumber)}` : backfillResult.status}
+              </div>
+            </div>
+            <div className="tw-grid tw-grid-cols-2 md:tw-grid-cols-4 tw-gap-2">
+              {resultRows.map(([label, value]) => (
+                <div key={label} className="tw-bg-white tw-rounded tw-p-2">
+                  <div className="tw-text-xs tw-text-gray-500">{label}</div>
+                  <div className="tw-text-lg tw-font-semibold tw-text-gray-900">{value}</div>
+                </div>
+              ))}
+            </div>
+            {backfillResult.message && (
+              <p className="tw-text-sm tw-text-gray-500 tw-mt-3 tw-mb-0">{backfillResult.message}</p>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  };
+
   const renderWorkerListContent = () => {
     if (isLoadingWorkers) {
       return <p className="tw-text-gray-500 tw-py-4 tw-mb-0">Loading workers...</p>;
@@ -965,19 +1156,35 @@ const MyOrganization: React.FC<Props> = ({ name, organization, role, alert }) =>
           </div>
 
           {canEditOrganization && (
-            <div className="card mt-3 mb-3 pl-5 pr-5">
-              <div className="card-body">
-                <div className="tw-flex tw-flex-col sm:tw-flex-row sm:tw-items-start sm:tw-justify-between tw-gap-2 tw-mb-4">
-                  <div>
-                    <h5 className="card-title tw-mb-1">Generate Report</h5>
-                    <p className="tw-text-sm tw-text-gray-500 tw-mb-0">
-                      Create a copy-ready activity summary for a date or date range.
-                    </p>
+            <>
+              <div className="card mt-3 mb-3 pl-5 pr-5">
+                <div className="card-body">
+                  <div className="tw-flex tw-flex-col sm:tw-flex-row sm:tw-items-start sm:tw-justify-between tw-gap-2 tw-mb-4">
+                    <div>
+                      <h5 className="card-title tw-mb-1">Generate Report</h5>
+                      <p className="tw-text-sm tw-text-gray-500 tw-mb-0">
+                        Create a copy-ready activity summary for a date or date range.
+                      </p>
+                    </div>
                   </div>
+                  {renderReportContent()}
                 </div>
-                {renderReportContent()}
               </div>
-            </div>
+
+              <div className="card mt-3 mb-3 pl-5 pr-5">
+                <div className="card-body">
+                  <div className="tw-flex tw-flex-col sm:tw-flex-row sm:tw-items-start sm:tw-justify-between tw-gap-2 tw-mb-4">
+                    <div>
+                      <h5 className="card-title tw-mb-1">Twilio Message Backfill</h5>
+                      <p className="tw-text-sm tw-text-gray-500 tw-mb-0">
+                        Recover historical SMS into Communications from Twilio without duplicating existing messages.
+                      </p>
+                    </div>
+                  </div>
+                  {renderTwilioBackfillContent()}
+                </div>
+              </div>
+            </>
           )}
 
           <div className="card mt-3 mb-3 pl-5 pr-5">

--- a/src/components/Communications/CallsPage.tsx
+++ b/src/components/Communications/CallsPage.tsx
@@ -1,5 +1,6 @@
 import './communications.css';
 
+import LocalPhoneOutlinedIcon from '@mui/icons-material/LocalPhoneOutlined';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -378,25 +379,33 @@ export default function CallsPage() {
 
             {isCalling && (
               <div className="call-modal-backdrop" role="presentation">
-                <section className="call-modal" aria-label="Call client">
+                <section className="call-modal" aria-label="Phone dialer">
                   <button type="button" className="call-close" onClick={() => setIsCalling(false)} aria-label="Close call modal">
                     ×
                   </button>
                   <div className="call-modal-header">
                     <span className="contact-avatar large">{selected.displayName.charAt(0).toUpperCase()}</span>
                     <div>
-                      <p className="communications-kicker">Call client</p>
+                      <p className="communications-kicker">Phone dialer</p>
                       <h2>{selected.displayName}</h2>
-                      <strong>{phone(selected.phone)}</strong>
                     </div>
                   </div>
+                  <label className="call-number-wrap">
+                    Phone number
+                    <input className="call-number-input" value={phone(selected.phone)} readOnly />
+                  </label>
                   <label className="call-notes-wrap">
                     Notes
                     <textarea className="call-notes" placeholder="Add notes during or after the call..." />
                   </label>
                   <div className="call-controls">
                     <button type="button" onClick={() => setIsCalling(false)}>Cancel</button>
-                    <a className={`call-start ${selected.phone ? '' : 'disabled'}`} href={selected.phone ? `tel:${selected.phone}` : undefined}>
+                    <a
+                      className={`call-start ${selected.phone ? '' : 'disabled'}`}
+                      href={selected.phone ? `tel:${selected.phone}` : undefined}
+                      aria-label={selected.phone ? `Call ${phone(selected.phone)}` : 'No phone number available'}
+                    >
+                      <LocalPhoneOutlinedIcon fontSize="small" />
                       Call
                     </a>
                   </div>

--- a/src/components/Communications/CallsPage.tsx
+++ b/src/components/Communications/CallsPage.tsx
@@ -7,6 +7,7 @@ import {
   Conversation,
   getConversations,
   getMessageBoard,
+  getMessageBoardByPhone,
   MessageBoardItem,
   scheduleMessage,
   sendMessage,
@@ -120,10 +121,12 @@ export default function CallsPage() {
     }
   }
 
-  async function loadThread(username: string) {
+  async function loadThread(conversation: Conversation) {
     setIsLoadingThread(true);
     try {
-      const data = await getMessageBoard(username);
+      const data = conversation.username
+        ? await getMessageBoard(conversation.username)
+        : await getMessageBoardByPhone(conversation.phone || '');
       if (data.status !== 'SUCCESS') {
         throw new Error(data.message || data.status);
       }
@@ -142,13 +145,13 @@ export default function CallsPage() {
   }, []);
 
   useEffect(() => {
-    if (selected?.username) {
-      loadThread(selected.username);
+    if (selected?.username || selected?.phone) {
+      loadThread(selected);
     } else if (selected) {
       setItems([]);
       setThreadError('');
     }
-  }, [selected?.username]);
+  }, [selected?.username, selected?.phone]);
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -375,30 +378,27 @@ export default function CallsPage() {
 
             {isCalling && (
               <div className="call-modal-backdrop" role="presentation">
-                <section className="call-modal" aria-label="Active call">
+                <section className="call-modal" aria-label="Call client">
                   <button type="button" className="call-close" onClick={() => setIsCalling(false)} aria-label="Close call modal">
                     ×
                   </button>
                   <div className="call-modal-header">
                     <span className="contact-avatar large">{selected.displayName.charAt(0).toUpperCase()}</span>
                     <div>
-                      <p className="communications-kicker">Calling</p>
+                      <p className="communications-kicker">Call client</p>
                       <h2>{selected.displayName}</h2>
                       <strong>{phone(selected.phone)}</strong>
                     </div>
-                    <span className="call-timer">00:42</span>
                   </div>
                   <label className="call-notes-wrap">
-                    Call notes
-                    <textarea className="call-notes" placeholder="Take call notes while you talk..." defaultValue="Client is asking whether a shelter letter can count as proof of address." />
-                  </label>
-                  <label className="call-volume">
-                    Volume
-                    <input type="range" min="0" max="100" defaultValue="72" aria-label="Call volume" />
+                    Notes
+                    <textarea className="call-notes" placeholder="Add notes during or after the call..." />
                   </label>
                   <div className="call-controls">
-                    <button type="button">Mute</button>
-                    <button type="button" className="end-call" onClick={() => setIsCalling(false)}>End</button>
+                    <button type="button" onClick={() => setIsCalling(false)}>Cancel</button>
+                    <a className={`call-start ${selected.phone ? '' : 'disabled'}`} href={selected.phone ? `tel:${selected.phone}` : undefined}>
+                      Call
+                    </a>
                   </div>
                 </section>
               </div>

--- a/src/components/Communications/communications.css
+++ b/src/components/Communications/communications.css
@@ -489,12 +489,25 @@ body:has(.communications-shell),
   color: #52616f;
 }
 
+.call-number-wrap,
 .call-notes-wrap {
   display: grid;
   gap: 6px;
   color: #334e68;
   font-size: 13px;
   font-weight: 800;
+}
+
+.call-number-input {
+  width: 100%;
+  border: 1px solid #bcccdc;
+  border-radius: 10px;
+  padding: 12px 14px;
+  background: #f8fafc;
+  color: #102a43;
+  font-size: 22px;
+  font-weight: 800;
+  text-align: center;
 }
 
 .call-notes {
@@ -526,6 +539,9 @@ body:has(.communications-shell),
 }
 
 .call-controls .call-start {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   border-color: #2f80ed;
   background: #2f80ed;
   color: #fff;

--- a/src/components/Communications/communications.css
+++ b/src/components/Communications/communications.css
@@ -469,7 +469,7 @@ body:has(.communications-shell),
 
 .call-modal-header {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr);
   gap: 14px;
   align-items: center;
 }
@@ -489,14 +489,7 @@ body:has(.communications-shell),
   color: #52616f;
 }
 
-.call-timer {
-  color: #102a43;
-  font-size: 22px;
-  font-weight: 800;
-}
-
-.call-notes-wrap,
-.call-volume {
+.call-notes-wrap {
   display: grid;
   gap: 6px;
   color: #334e68;
@@ -515,30 +508,32 @@ body:has(.communications-shell),
   font-weight: 400;
 }
 
-.call-volume input {
-  width: 100%;
-  accent-color: #2f80ed;
-}
-
 .call-controls {
   display: flex;
-  justify-content: center;
+  justify-content: flex-end;
   gap: 10px;
 }
 
-.call-controls button {
+.call-controls button,
+.call-controls a {
   border: 1px solid #bcccdc;
   border-radius: 999px;
   padding: 10px 18px;
   background: #fff;
   color: #102a43;
   font-weight: 800;
+  text-decoration: none;
 }
 
-.call-controls .end-call {
-  border-color: #e53e3e;
-  background: #e53e3e;
+.call-controls .call-start {
+  border-color: #2f80ed;
+  background: #2f80ed;
   color: #fff;
+}
+
+.call-controls .call-start.disabled {
+  pointer-events: none;
+  opacity: 0.55;
 }
 
 .profile-notes-preview {

--- a/src/components/Communications/communicationsApi.ts
+++ b/src/components/Communications/communicationsApi.ts
@@ -127,6 +127,11 @@ export function getMessageBoard(username: string) {
   return jsonFetch<MessageBoardResponse>(`/api/client-profiles/${encodeURIComponent(username)}/message-board`);
 }
 
+export function getMessageBoardByPhone(phone: string) {
+  const params = new URLSearchParams({ phone });
+  return jsonFetch<MessageBoardResponse>(`/api/communications/message-board?${params.toString()}`);
+}
+
 export function addClientNote(username: string, body: string, callLogId?: string) {
   return jsonFetch<MessageBoardResponse>(`/api/client-profiles/${encodeURIComponent(username)}/notes`, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- Recover the communications call modal cleanup that was pushed after PR #627 was opened but did not land in `server-migration`.
- Replace the fake active-call state, hard-coded `00:42` timer, and prefilled notes with a phone-dialer modal.
- Show the selected client phone number prefilled in the modal, with an empty notes box.
- Start the call only when the worker clicks the phone/Call button; opening the modal does not initiate a call.
- Recover phone-only message-board loading for unmatched phone conversations.
- Recover the admin-only Twilio Message Backfill card in My Organization.

## Verification
- `npm run build`
- `npx eslint src/components/Communications/CallsPage.tsx src/components/Communications/communicationsApi.ts src/components/AccountSettings/MyOrganization.tsx --ext .ts,.tsx`

## Screenshots
- Not captured in this pass; this PR recovers previously pushed UI commits that were missed by the prior merge.

## Notes
- The call action opens the user/device system dialer via `tel:`. It does not implement Twilio Voice in-browser calling yet; that would be a separate server/client feature with Twilio Voice SDK tokens and call webhooks.