### PR TITLE
[codex] Show all supported application start options

### DIFF
--- a/src/components/Applications/ViewApplications.tsx
+++ b/src/components/Applications/ViewApplications.tsx
@@ -766,7 +766,7 @@ class ViewApplications extends Component<Props & RouteComponentProps, State, {}>
                     </div>
                     {availableApplications.length > 0 ? (
                       <div className="tw-mt-3 tw-space-y-2">
-                        {availableApplications.slice(0, 4).map((application) => (
+                        {availableApplications.map((application) => (
                           <Link
                             key={application.lookupKey}
                             to={{


### PR DESCRIPTION
## Summary
- Restore the full supported application list in the Applications quick-start panel.
- Removes the accidental four-item cap introduced by the miscellaneous upload layout.

## Verification
- `npx eslint src/components/Applications/ViewApplications.tsx`

## Screenshots
- Not captured; one-line list rendering fix.

## Notes
- This is a follow-up to PR #630 because the fix was pushed after that PR had already merged.
