### PR TITLE
Show hotline call recordings

### DIFF
--- a/src/components/Communications/CallsPage.tsx
+++ b/src/components/Communications/CallsPage.tsx
@@ -12,6 +12,7 @@ import {
   addClientNote,
   Conversation,
   formatDuration,
+  getCallRecordingPlaybackUrl,
   getConversations,
   getMessageBoard,
   getMessageBoardByPhone,
@@ -100,6 +101,11 @@ function itemTitle(item: MessageBoardItem) {
     return 'Voice Mail Transcript';
   }
   return item.title;
+}
+
+function recordingPlaybackUrl(item: MessageBoardItem) {
+  if (!item.recordingUrl || (item.type !== 'call' && item.type !== 'voicemail')) return '';
+  return getCallRecordingPlaybackUrl(item.sourceId);
 }
 
 function conversationInitial(conversation: Conversation) {
@@ -603,6 +609,7 @@ export default function CallsPage() {
               {visibleItems.map((item) => {
                 const side = itemSide(item);
                 const title = itemTitle(item);
+                const recordingUrl = recordingPlaybackUrl(item);
                 return (
                   <article key={`${item.type}-${item.sourceId}`} className={`chat-item ${side} ${item.type}`}>
                     <div className="chat-bubble">
@@ -655,6 +662,15 @@ export default function CallsPage() {
                         </div>
                       ) : (
                         item.body && <p>{item.body}</p>
+                      )}
+                      {recordingUrl && (
+                        <div className="recording-player">
+                          {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+                          <audio controls preload="none" src={recordingUrl}>
+                            Recording playback is not supported in this browser.
+                          </audio>
+                          <a href={recordingUrl} target="_blank" rel="noreferrer">Open recording</a>
+                        </div>
                       )}
                       {item.status && item.type !== 'call' && item.type !== 'voicemail' && <small>{item.status}</small>}
                     </div>

--- a/src/components/Communications/communications.css
+++ b/src/components/Communications/communications.css
@@ -823,6 +823,28 @@ body:has(.communications-shell),
   white-space: pre-wrap;
 }
 
+.recording-player {
+  display: grid;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.recording-player audio {
+  width: min(100%, 360px);
+  height: 36px;
+}
+
+.recording-player a {
+  color: #2f80ed;
+  font-size: 12px;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.recording-player a:hover {
+  text-decoration: underline;
+}
+
 .timeline-entry small {
   display: block;
   margin-top: 3px;

--- a/src/components/Communications/communicationsApi.ts
+++ b/src/components/Communications/communicationsApi.ts
@@ -14,6 +14,10 @@ export type CallLog = {
   noteCount: number;
   latestNote?: string;
   voicemailTranscript?: string;
+  voicemailRecordingUrl?: string;
+  callTranscript?: string;
+  callRecordingUrl?: string;
+  transcriptionSid?: string;
 };
 
 export type CallsReport = {
@@ -57,6 +61,7 @@ export type MessageBoardItem = {
   body?: string;
   status?: string;
   metadata?: string;
+  recordingUrl?: string;
 };
 
 export type CallsResponse = {
@@ -173,6 +178,10 @@ export function scheduleMessage(username: string, body: string, sendAt: string, 
 
 export function getTwilioVoiceToken() {
   return jsonFetch<TwilioVoiceTokenResponse>('/api/communications/voice/token');
+}
+
+export function getCallRecordingPlaybackUrl(callId: string) {
+  return `${getServerURL()}/api/communications/calls/${encodeURIComponent(callId)}/recording`;
 }
 
 export function formatDuration(seconds?: number) {

--- a/src/components/Profile/ClientTimelineSection.tsx
+++ b/src/components/Profile/ClientTimelineSection.tsx
@@ -5,6 +5,7 @@ import { useAlert } from 'react-alert';
 
 import getServerURL from '../../serverOverride';
 import {
+  getCallRecordingPlaybackUrl,
   getMessageBoard,
   MessageBoardItem,
   updateClientNote,
@@ -25,6 +26,7 @@ type TimelineEntry = {
   editable?: boolean;
   workerNoteIndex?: number;
   communicationNoteId?: string;
+  recordingUrl?: string;
 };
 
 type SaveState = 'idle' | 'saving' | 'saved';
@@ -144,6 +146,9 @@ function toTimelineItem(item: MessageBoardItem): TimelineEntry {
     source: shouldShowSource(item) ? sourceLabel(item) : undefined,
     editable: item.type === 'note',
     communicationNoteId: item.type === 'note' ? item.sourceId : undefined,
+    recordingUrl: item.recordingUrl && (item.type === 'call' || item.type === 'voicemail')
+      ? getCallRecordingPlaybackUrl(item.sourceId)
+      : undefined,
   };
 }
 
@@ -382,6 +387,15 @@ export default function ClientTimelineSection({ username, workerNotes, onSaved }
                         </div>
                       ) : (
                         <p>{item.body}</p>
+                      )}
+                      {item.recordingUrl && (
+                        <div className="recording-player">
+                          {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+                          <audio controls preload="none" src={item.recordingUrl}>
+                            Recording playback is not supported in this browser.
+                          </audio>
+                          <a href={item.recordingUrl} target="_blank" rel="noreferrer">Open recording</a>
+                        </div>
                       )}
                       {item.source && <small>{item.source}</small>}
                     </div>


### PR DESCRIPTION
## Summary
- Add audio playback controls for call and voicemail items in Communications and client profile timelines.
- Route playback through the server recording proxy instead of asking the browser to fetch Twilio media directly.
- Extend communication API types for call transcript and recording fields.

## Verification
- `git diff --check`
- `npx eslint src/components/Communications/communicationsApi.ts src/components/Communications/CallsPage.tsx src/components/Profile/ClientTimelineSection.tsx --ext .ts,.tsx`
- `npm run build`
- `npm run lint:ts` fails on pre-existing unrelated lint errors outside this change; touched files pass targeted lint.

## Screenshots
- N/A; recording controls only render when the backend returns a recording URL for a call/voicemail item.
