### PR TITLE
June bug fixes

### DIFF
--- a/src/components/Documents/DocumentsInlineUpload.tsx
+++ b/src/components/Documents/DocumentsInlineUpload.tsx
@@ -8,13 +8,9 @@ import { Link } from 'react-router-dom';
 import getServerURL from '../../serverOverride';
 import FileType from '../../static/FileType';
 import {
-  buildClientDocumentsUrl,
-  buildPickupEmailBody,
-  buildPickupEmailSubject,
   buildPickupMessage,
   EMPTY_ORG_ADDRESS,
   formatIdLabel,
-  isValidEmail,
   isValidUSPhone,
   OrgAddress,
   toE164US,
@@ -133,7 +129,6 @@ export default function DocumentsInlineUpload({
   const [showNotifyConfirm, setShowNotifyConfirm] = useState(false);
   const [clientDisplayName, setClientDisplayName] = useState<string>(clientNameProp || '');
   const [clientPhone, setClientPhone] = useState<string>('');
-  const [clientEmail, setClientEmail] = useState<string>('');
   const [orgAddress, setOrgAddress] = useState<OrgAddress>(EMPTY_ORG_ADDRESS);
   const [notifyHydrated, setNotifyHydrated] = useState(false);
   const [sendingNotification, setSendingNotification] = useState(false);
@@ -270,7 +265,6 @@ export default function DocumentsInlineUpload({
               .trim();
             setClientDisplayName((prev) => prev || fetchedName);
             setClientPhone((prev) => prev || (data.phone || ''));
-            setClientEmail((prev) => prev || (data.email || ''));
           }
         }
 
@@ -318,24 +312,6 @@ export default function DocumentsInlineUpload({
     }),
     [clientDisplayName, viewerName, effectiveCategoryLabel, orgAddress],
   );
-
-  // Email channel is opt-in: only built when the client has a valid email on
-  // file. Subject/body shown in the confirm modal are the same strings sent to
-  // the backend so staff see exactly what the client will receive.
-  const emailPreview = useMemo(() => {
-    if (!isValidEmail(clientEmail)) return null;
-    const documentLink = buildClientDocumentsUrl();
-    const subject = buildPickupEmailSubject(effectiveCategoryLabel);
-    const { text, html } = buildPickupEmailBody({
-      clientName: clientDisplayName,
-      idCategory: effectiveCategoryLabel,
-      organizationName,
-      orgAddress,
-      clientEmail,
-      documentLink,
-    });
-    return { subject, text, html };
-  }, [clientDisplayName, clientEmail, effectiveCategoryLabel, orgAddress, organizationName]);
 
   const notifyDisabledReason = useMemo(() => {
     if (!canNotify) return '';
@@ -553,23 +529,11 @@ export default function DocumentsInlineUpload({
             idToPickup: formatIdLabel(effectiveCategoryLabel),
             clientPhoneNumber: toE164US(clientPhone),
             message: previewMessage,
-            ...(emailPreview
-              ? {
-                clientEmail,
-                emailSubject: emailPreview.subject,
-                emailBody: emailPreview.text,
-                emailHtml: emailPreview.html,
-              }
-              : {}),
           }),
         });
         const data = await res.json().catch(() => ({} as any));
         if (res.ok && data?.status === 'SUCCESS') {
-          alert.show(
-            emailPreview
-              ? 'Document uploaded. SMS + email sent to client.'
-              : 'Document uploaded. Notification sent to client.',
-          );
+          alert.show('Document uploaded. Notification sent to client.');
         } else {
           // Upload still succeeded; surface the notify failure separately so
           // staff know the doc is saved and they can retry the SMS from the
@@ -605,10 +569,8 @@ export default function DocumentsInlineUpload({
     canNotify,
     category,
     canSendNotify,
-    clientEmail,
     clientPhone,
     effectiveCategoryLabel,
-    emailPreview,
     notifyDisabledReason,
     onUploadComplete,
     previewMessage,
@@ -998,7 +960,8 @@ export default function DocumentsInlineUpload({
               </div>
               <div className="modal-body">
                 <p className="mb-2">
-                  A text message was sent to your phone with a secure upload link.
+                  A text message was sent to {clientDisplayName || targetUser}
+                  {clientPhone ? ` at ${clientPhone}` : ''} with a secure upload link.
                 </p>
                 {phoneUploadExpiresAt ? (
                   <p className="small text-muted mb-3">
@@ -1094,28 +1057,6 @@ export default function DocumentsInlineUpload({
                 >
                   {previewMessage}
                 </div>
-                {emailPreview ? (
-                  <div className="mb-3">
-                    <p className="small text-muted mb-1">
-                      Will also email <strong>{clientEmail}</strong>
-                    </p>
-                    <div className="border rounded bg-light p-3">
-                      <p className="fw-semibold mb-2">{emailPreview.subject}</p>
-                      <p
-                        className="mb-0 small"
-                        style={{ whiteSpace: 'pre-wrap' }}
-                      >
-                        {emailPreview.text}
-                      </p>
-                    </div>
-                  </div>
-                ) : (
-                  <p className="small text-muted mb-3">
-                    {clientEmail
-                      ? `Email "${clientEmail}" looks invalid; only an SMS will be sent.`
-                      : 'No email on file for this client. Only an SMS will be sent.'}
-                  </p>
-                )}
                 <p className="small text-muted mb-0">
                   A copy is saved in this client&apos;s{' '}
                   <Link to={notifyPanelPath} onClick={() => setShowNotifyConfirm(false)}>

--- a/src/components/InteractiveForms/InteractiveFormWizard.tsx
+++ b/src/components/InteractiveForms/InteractiveFormWizard.tsx
@@ -2,7 +2,7 @@ import type { UISchemaElement } from '@jsonforms/core';
 import { JsonForms } from '@jsonforms/react';
 import React, { useCallback, useState } from 'react';
 
-import { normalizeDateLikeValue, resolveDirectiveFromProfiles } from '../../utils/directives';
+import { normalizeDateLikeValue, resolveDirectiveFromProfilesForTarget } from '../../utils/directives';
 import { WizardSubmitProvider } from './InteractiveFormWizardContext';
 import { interactiveFormCells, interactiveFormRenderers } from './renderers';
 import { type AutoFillField, type BuilderState, type OutputFieldDefinition, computeMetadata } from './types';
@@ -25,7 +25,7 @@ export function applyAutoFillFields(
     }
     let val: unknown;
     if (af.valueSource === 'directive' && af.value) {
-      val = resolveDirectiveFromProfiles(af.value, resolvedProfiles as never);
+      val = resolveDirectiveFromProfilesForTarget(af.value, resolvedProfiles as never, af.pdfFieldName);
     } else if (af.valueSource === 'literal') {
       val = af.value;
     }

--- a/src/components/InteractiveForms/InteractiveFormWizard.tsx
+++ b/src/components/InteractiveForms/InteractiveFormWizard.tsx
@@ -18,9 +18,7 @@ export function applyAutoFillFields(
   autoFillFields.forEach((af) => {
     if (!af.pdfFieldName) return;
     if (af.fieldType === 'checkbox') {
-      // Optional override for non-standard encodings: allow explicit token
-      // (e.g. Choice2-...) instead of generic "true".
-      merged[af.pdfFieldName] = af.value && af.value.trim() !== '' ? af.value : 'true';
+      merged[af.pdfFieldName] = 'true';
       return;
     }
     let val: unknown;

--- a/src/components/InteractiveForms/useInteractiveForm.test.ts
+++ b/src/components/InteractiveForms/useInteractiveForm.test.ts
@@ -149,7 +149,7 @@ describe('interactive form PDF fill directives', () => {
       fixedDirectorBirthYear: '1918',
       fixedClientPhoneArea: '215',
       fixedLiteral: 'Static outcome',
-      fixedCheckbox: 'Choice2',
+      fixedCheckbox: 'true',
     });
   });
 

--- a/src/components/InteractiveForms/useInteractiveForm.test.ts
+++ b/src/components/InteractiveForms/useInteractiveForm.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { applyAutoFillFields } from './InteractiveFormWizard';
-import { buildFormAnswers } from './useInteractiveForm';
-import type { AutoFillField } from './types';
 import type { ResolvedProfiles } from '../../utils/directives';
+import { applyAutoFillFields } from './InteractiveFormWizard';
+import type { AutoFillField } from './types';
+import { buildFormAnswers, extractDirectivesFromUiSchema } from './useInteractiveForm';
 
 const resolvedProfiles: ResolvedProfiles = {
   client: {
@@ -17,6 +17,7 @@ const resolvedProfiles: ResolvedProfiles = {
       state: 'PA',
       zip: '19104',
     },
+    motherName: { first: 'Anne', last: 'Byron', maiden: 'Milbanke' },
   },
   worker: {
     currentName: { first: 'Grace', last: 'Hopper' },
@@ -160,5 +161,58 @@ describe('interactive form PDF fill directives', () => {
         resolvedProfiles as Record<string, unknown>,
       ),
     ).toEqual({ existing: 'keep me' });
+  });
+
+  it('fills mother maiden targets from motherName.maiden even when legacy config points at motherName.last', () => {
+    const uiSchema = {
+      type: 'VerticalLayout',
+      elements: [
+        {
+          type: 'Control',
+          label: "Mother's maiden name",
+          scope: '#/properties/motherMaiden',
+          options: { pdfField: 'mother_maiden_name', directive: 'client.motherName.last' },
+        },
+        {
+          type: 'Control',
+          label: "Mother's current last name",
+          scope: '#/properties/motherLast',
+          options: { pdfField: 'mother_last_name', directive: 'client.motherName.last' },
+        },
+      ],
+    };
+
+    expect(buildFormAnswers(uiSchema, jsonSchema, {}, resolvedProfiles)).toEqual({
+      mother_maiden_name: 'Milbanke',
+      mother_last_name: 'Byron',
+    });
+  });
+
+  it('fills hidden mother maiden PDF fields from motherName.maiden', () => {
+    expect(
+      applyAutoFillFields(
+        {},
+        [{ pdfFieldName: 'mother_maiden_name', valueSource: 'directive', value: 'client.motherName.last' }],
+        resolvedProfiles as Record<string, unknown>,
+      ),
+    ).toEqual({ mother_maiden_name: 'Milbanke' });
+  });
+
+  it('syncs mother maiden answers back to motherName.maiden for legacy motherName.last directives', () => {
+    const uiSchema = {
+      type: 'VerticalLayout',
+      elements: [
+        {
+          type: 'Control',
+          label: "Mother's maiden name",
+          scope: '#/properties/motherMaiden',
+          options: { directive: 'client.motherName.last' },
+        },
+      ],
+    };
+
+    expect(extractDirectivesFromUiSchema(uiSchema, { motherMaiden: 'Milbanke' })).toEqual({
+      'client.motherName.maiden': 'Milbanke',
+    });
   });
 });

--- a/src/components/InteractiveForms/useInteractiveForm.ts
+++ b/src/components/InteractiveForms/useInteractiveForm.ts
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import {
+  canonicalDirectiveForTarget,
   getByPath,
   isExcludedFromProfileFormSync,
   normalizeDateLikeValue,
-  resolveDirectiveFromProfiles,
+  resolveDirectiveFromProfilesForTarget,
 } from '../../utils/directives';
 import {
   type GetQuestionsV2Response,
@@ -78,6 +79,12 @@ function resolveConditionalDirective(
   return match?.use ?? null;
 }
 
+function targetText(...values: unknown[]): string {
+  return values
+    .filter((value): value is string => typeof value === 'string' && value.trim() !== '')
+    .join(' ');
+}
+
 export function buildFormAnswers(
   uiSchema: Record<string, unknown>,
   jsonSchema: Record<string, unknown>,
@@ -114,9 +121,10 @@ export function buildFormAnswers(
         const pdfField = options.pdfField as string;
         let value: unknown = getPropValue(scope);
         const directive = options.directive;
+        const targetName = targetText(element.label, pdfField);
         if (directive != null && resolvedProfiles) {
           if (typeof directive === 'string') {
-            const resolved = resolveDirectiveFromProfiles(directive, resolvedProfiles);
+            const resolved = resolveDirectiveFromProfilesForTarget(directive, resolvedProfiles, targetName);
             if (resolved !== undefined) value = resolved;
           } else if (Array.isArray(directive)) {
             const useDirective = resolveConditionalDirective(
@@ -124,7 +132,7 @@ export function buildFormAnswers(
               data,
             );
             if (useDirective) {
-              const resolved = resolveDirectiveFromProfiles(useDirective, resolvedProfiles);
+              const resolved = resolveDirectiveFromProfilesForTarget(useDirective, resolvedProfiles, targetName);
               if (resolved !== undefined) value = resolved;
             }
           }
@@ -167,14 +175,22 @@ export function buildFormAnswers(
               if (explicitFill === ON_PLACEHOLDER) return;
               fillVal = explicitFill;
             } else if (m.directive && resolvedProfiles) {
-              fillVal = resolveDirectiveFromProfiles(m.directive as string, resolvedProfiles);
+              fillVal = resolveDirectiveFromProfilesForTarget(
+                m.directive as string,
+                resolvedProfiles,
+                targetText(element.label, pdfField),
+              );
             } else {
               return;
             }
           } else if (explicitFill !== undefined && explicitFill !== null && explicitFill !== '') {
             fillVal = explicitFill;
           } else if (m.directive && resolvedProfiles) {
-            fillVal = resolveDirectiveFromProfiles(m.directive as string, resolvedProfiles);
+            fillVal = resolveDirectiveFromProfilesForTarget(
+              m.directive as string,
+              resolvedProfiles,
+              targetText(element.label, pdfField),
+            );
           } else {
             fillVal = currentVal;
           }
@@ -191,7 +207,11 @@ export function buildFormAnswers(
           if (!pdfField) return;
           if (!fillConditionMatches(fillCond, data)) return;
           const fillVal = cf.fillValue ?? (resolvedProfiles && cf.directive
-            ? resolveDirectiveFromProfiles(cf.directive as string, resolvedProfiles)
+            ? resolveDirectiveFromProfilesForTarget(
+              cf.directive as string,
+              resolvedProfiles,
+              targetText(element.label, pdfField),
+            )
             : baseValue);
           if (fillVal !== undefined && fillVal !== null && fillVal !== '') {
             out[pdfField] = formatDateForPdf(fillVal);
@@ -231,14 +251,22 @@ export function buildFormAnswers(
                 if (explicitFill === ON_PLACEHOLDER) return;
                 fillVal = explicitFill;
               } else if (m.directive && resolvedProfiles) {
-                fillVal = resolveDirectiveFromProfiles(m.directive as string, resolvedProfiles);
+                fillVal = resolveDirectiveFromProfilesForTarget(
+                  m.directive as string,
+                  resolvedProfiles,
+                  targetText(element.label, pdfField),
+                );
               } else {
                 return;
               }
             } else if (explicitFill !== undefined && explicitFill !== null && explicitFill !== '') {
               fillVal = explicitFill;
             } else if (m.directive && resolvedProfiles) {
-              fillVal = resolveDirectiveFromProfiles(m.directive as string, resolvedProfiles);
+              fillVal = resolveDirectiveFromProfilesForTarget(
+                m.directive as string,
+                resolvedProfiles,
+                targetText(element.label, pdfField),
+              );
             } else {
               fillVal = val;
             }
@@ -254,7 +282,11 @@ export function buildFormAnswers(
           if (!pdfField) return;
           if (!fillConditionMatches(fillCond, data)) return;
           const fillVal = cf.fillValue ?? (cf.directive && resolvedProfiles
-            ? resolveDirectiveFromProfiles(cf.directive as string, resolvedProfiles) : baseValue);
+            ? resolveDirectiveFromProfilesForTarget(
+              cf.directive as string,
+              resolvedProfiles,
+              targetText(element.label, pdfField),
+            ) : baseValue);
           if (fillVal !== undefined && fillVal !== null && fillVal !== '') {
             out[pdfField] = formatDateForPdf(fillVal);
           }
@@ -317,14 +349,22 @@ function buildInitialData(
       const directive = options?.directive;
       if (directive != null && resolvedProfiles) {
         if (typeof directive === 'string') {
-          value = resolveDirectiveFromProfiles(directive, resolvedProfiles);
+          value = resolveDirectiveFromProfilesForTarget(
+            directive,
+            resolvedProfiles,
+            targetText(element.label, scope),
+          );
         } else if (Array.isArray(directive)) {
           const useDirective = resolveConditionalDirective(
             directive as Array<{ when?: { scope?: string; schema?: Record<string, unknown> }; use: string }>,
             out,
           );
           if (useDirective) {
-            value = resolveDirectiveFromProfiles(useDirective, resolvedProfiles);
+            value = resolveDirectiveFromProfilesForTarget(
+              useDirective,
+              resolvedProfiles,
+              targetText(element.label, scope),
+            );
           }
         }
       }
@@ -456,16 +496,20 @@ export function extractDirectivesFromUiSchema(
         const value = getPropValue(scope);
         if (value !== undefined && value !== null && value !== '') {
           if (typeof directive === 'string') {
-            if (!isExcludedFromProfileFormSync(directive)) {
-              directivesMap[directive] = value;
+            const profileDirective = canonicalDirectiveForTarget(directive, targetText(element.label, scope));
+            if (!isExcludedFromProfileFormSync(profileDirective)) {
+              directivesMap[profileDirective] = value;
             }
           } else if (Array.isArray(directive)) {
             const useDirective = resolveConditionalDirective(
               directive as Array<{ when?: { scope?: string; schema?: Record<string, unknown> }; use: string }>,
               data,
             );
-            if (useDirective && !isExcludedFromProfileFormSync(useDirective)) {
-              directivesMap[useDirective] = value;
+            const profileDirective = useDirective
+              ? canonicalDirectiveForTarget(useDirective, targetText(element.label, scope))
+              : null;
+            if (profileDirective && !isExcludedFromProfileFormSync(profileDirective)) {
+              directivesMap[profileDirective] = value;
             }
           }
         }

--- a/src/components/Profile/ClientTimelineSection.tsx
+++ b/src/components/Profile/ClientTimelineSection.tsx
@@ -231,7 +231,6 @@ export default function ClientTimelineSection({ username, workerNotes, onSaved }
         occurredAt: entry.occurredAt,
         title: entry.migrated ? 'Migrated worker notes' : 'Worker note',
         body: entry.body,
-        source: 'Profile',
         editable: true,
         workerNoteIndex: index,
       });

--- a/src/components/Profile/ClientTimelineSection.tsx
+++ b/src/components/Profile/ClientTimelineSection.tsx
@@ -19,7 +19,7 @@ type Props = {
 
 type TimelineEntry = {
   id: string;
-  occurredAt: string;
+  occurredAt?: string;
   title: string;
   body: string;
   source?: string;
@@ -33,10 +33,12 @@ type SaveState = 'idle' | 'saving' | 'saved';
 
 type WorkerNoteEntry = {
   id: string;
-  occurredAt: string;
+  occurredAt?: string;
   body: string;
   migrated?: boolean;
 };
+
+const UNDATED_LABEL = 'Undated notes';
 
 function PencilIcon() {
   return (
@@ -53,19 +55,41 @@ function PencilIcon() {
   );
 }
 
-function dateKey(value: string) {
+function parseTimelineDate(value?: string | null) {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+
+  const dateOnly = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (dateOnly) {
+    const [, year, month, day] = dateOnly;
+    return new Date(Number(year), Number(month) - 1, Number(day), 12);
+  }
+
+  const parsed = new Date(trimmed);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function dateKey(value?: string) {
+  const parsed = parseTimelineDate(value);
+  if (!parsed) return UNDATED_LABEL;
   return new Intl.DateTimeFormat(undefined, {
     month: 'long',
     day: 'numeric',
     year: 'numeric',
-  }).format(new Date(value));
+  }).format(parsed);
 }
 
-function timeLabel(value: string) {
+function timeLabel(value?: string) {
+  const parsed = parseTimelineDate(value);
+  if (!parsed) return '';
   return new Intl.DateTimeFormat(undefined, {
     hour: 'numeric',
     minute: '2-digit',
-  }).format(new Date(value));
+  }).format(parsed);
+}
+
+function timelineTime(value?: string) {
+  return parseTimelineDate(value)?.getTime() ?? Number.NEGATIVE_INFINITY;
 }
 
 function sourceLabel(item: MessageBoardItem) {
@@ -95,17 +119,16 @@ function parseWorkerNotes(notes?: string): WorkerNoteEntry[] {
       const trimmed = block.trim();
       const match = trimmed.match(/^\[([^\]]+)]\s*\n?([\s\S]*)$/);
       if (match) {
-        const parsed = new Date(match[1]);
+        const parsed = parseTimelineDate(match[1]);
         return {
           id: `worker-note-${index}-${match[1]}`,
-          occurredAt: Number.isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString(),
+          occurredAt: parsed?.toISOString(),
           body: match[2].trim(),
-          migrated: false,
+          migrated: !parsed,
         };
       }
       return {
         id: `worker-note-${index}-legacy`,
-        occurredAt: new Date().toISOString(),
         body: trimmed,
         migrated: true,
       };
@@ -116,7 +139,11 @@ function parseWorkerNotes(notes?: string): WorkerNoteEntry[] {
 function serializeWorkerNotes(entries: WorkerNoteEntry[]) {
   return entries
     .filter((entry) => entry.body.trim())
-    .map((entry) => `[${dateKey(entry.occurredAt)} ${timeLabel(entry.occurredAt)}]\n${entry.body.trim()}`)
+    .map((entry) => (
+      entry.occurredAt
+        ? `[${dateKey(entry.occurredAt)} ${timeLabel(entry.occurredAt)}]\n${entry.body.trim()}`
+        : entry.body.trim()
+    ))
     .join('\n\n');
 }
 
@@ -137,7 +164,7 @@ function bodyLabel(item: MessageBoardItem) {
 }
 
 function toTimelineItem(item: MessageBoardItem): TimelineEntry {
-  const occurredAt = item.occurredAt || item.noteDate || new Date().toISOString();
+  const occurredAt = item.occurredAt || item.noteDate;
   return {
     id: `${item.type}-${item.sourceId}`,
     occurredAt,
@@ -155,20 +182,22 @@ function toTimelineItem(item: MessageBoardItem): TimelineEntry {
 function groupNearbyMessages(items: MessageBoardItem[]) {
   const groups: MessageBoardItem[][] = [];
   const sorted = [...items].sort((a, b) => {
-    const aTime = new Date(a.occurredAt || a.noteDate || 0).getTime();
-    const bTime = new Date(b.occurredAt || b.noteDate || 0).getTime();
+    const aTime = timelineTime(a.occurredAt || a.noteDate);
+    const bTime = timelineTime(b.occurredAt || b.noteDate);
     return aTime - bTime;
   });
 
   sorted.forEach((item) => {
     const lastGroup = groups[groups.length - 1];
     const lastItem = lastGroup?.[lastGroup.length - 1];
-    const itemTime = new Date(item.occurredAt || item.noteDate || 0).getTime();
-    const lastTime = new Date(lastItem?.occurredAt || lastItem?.noteDate || 0).getTime();
+    const itemTime = timelineTime(item.occurredAt || item.noteDate);
+    const lastTime = timelineTime(lastItem?.occurredAt || lastItem?.noteDate);
     const canGroup = lastItem
       && item.type === 'message'
       && lastItem.type === 'message'
       && item.metadata === lastItem.metadata
+      && itemTime !== Number.NEGATIVE_INFINITY
+      && lastTime !== Number.NEGATIVE_INFINITY
       && Math.abs(itemTime - lastTime) <= 2 * 60 * 1000;
 
     if (canGroup) {
@@ -237,7 +266,7 @@ export default function ClientTimelineSection({ username, workerNotes, onSaved }
     });
 
     return entries.sort((a, b) => (
-      new Date(a.occurredAt).getTime() - new Date(b.occurredAt).getTime()
+      timelineTime(a.occurredAt) - timelineTime(b.occurredAt)
     ));
   }, [communicationItems, workerNoteEntries]);
 

--- a/src/utils/directives.test.ts
+++ b/src/utils/directives.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   type ResolvedProfiles,
+  canonicalDirectiveForTarget,
   getByPath,
   isExcludedFromProfileFormSync,
   normalizeDateLikeValue,
   resolveDirectiveFromProfiles,
+  resolveDirectiveFromProfilesForTarget,
 } from './directives';
 
 const profiles: ResolvedProfiles = {
@@ -14,7 +16,12 @@ const profiles: ResolvedProfiles = {
     firstName: 'Ada',
     lastName: 'Lovelace',
     fatherName: { first: 'Lord', middle: 'Noel', last: 'Byron' },
-    motherName: { first: 'Anne', middle: 'Isabella', last: 'Milbanke' },
+    motherName: {
+      first: 'Anne',
+      middle: 'Isabella',
+      last: 'Byron',
+      maiden: 'Milbanke',
+    },
     birthDate: '1815-12-10',
     email: 'ada@example.org',
     sex: 'F',
@@ -71,9 +78,28 @@ describe('directive resolution', () => {
     expect(getByPath({ 'currentName.first': 'Flat', currentName: { first: 'Nested' } }, 'currentName.first')).toBe('Flat');
     expect(resolveDirectiveFromProfiles('client.currentName.first', profiles)).toBe('Ada');
     expect(resolveDirectiveFromProfiles('client.fatherName.middle', profiles)).toBe('Noel');
-    expect(resolveDirectiveFromProfiles('client.motherName.last', profiles)).toBe('Milbanke');
+    expect(resolveDirectiveFromProfiles('client.motherName.last', profiles)).toBe('Byron');
+    expect(resolveDirectiveFromProfiles('client.motherName.maiden', profiles)).toBe('Milbanke');
+    expect(resolveDirectiveFromProfiles('dummy:client.motherName.maiden', profiles)).toBe('Milbanke');
     expect(resolveDirectiveFromProfiles('worker.currentName.last', profiles)).toBe('Hopper');
     expect(resolveDirectiveFromProfiles('director.email', profiles)).toBe('kj@example.org');
+  });
+
+  it('does not use mother married last name for mother maiden targets', () => {
+    expect(canonicalDirectiveForTarget('client.motherName.last', "Mother's maiden name"))
+      .toBe('client.motherName.maiden');
+    expect(canonicalDirectiveForTarget('dummy:client.motherName.last', 'Mother maiden last'))
+      .toBe('dummy:client.motherName.maiden');
+    expect(resolveDirectiveFromProfilesForTarget(
+      'client.motherName.last',
+      profiles,
+      "Mother's Maiden Name",
+    )).toBe('Milbanke');
+    expect(resolveDirectiveFromProfilesForTarget(
+      'client.motherName.last',
+      profiles,
+      "Mother's current last name",
+    )).toBe('Byron');
   });
 
   it('normalizes date-like direct values', () => {

--- a/src/utils/directives.ts
+++ b/src/utils/directives.ts
@@ -95,6 +95,14 @@ function isBlankValue(value: unknown): boolean {
   return value === undefined || value === null || (typeof value === 'string' && value.trim() === '');
 }
 
+function stripDirectiveNamespace(directive: string): string {
+  const trimmed = directive.trim();
+  const lastColon = trimmed.lastIndexOf(':');
+  return lastColon >= 0 && lastColon + 1 < trimmed.length
+    ? trimmed.slice(lastColon + 1)
+    : trimmed;
+}
+
 function resolveProfilePath(profile: Record<string, unknown> | undefined, path: string): unknown {
   const value = getByPath(profile, path);
   if (!isBlankValue(value)) return value;
@@ -107,6 +115,30 @@ function resolveProfilePath(profile: Record<string, unknown> | undefined, path: 
   };
   const fallbackPath = nameAlias[path];
   return fallbackPath ? getByPath(profile, fallbackPath) : value;
+}
+
+function isMotherMaidenTarget(targetName: unknown): boolean {
+  if (typeof targetName !== 'string') return false;
+  const normalized = targetName.toLowerCase();
+  return normalized.includes('mother') && normalized.includes('maiden');
+}
+
+function isMotherLastDirective(directive: string): boolean {
+  return /^(client\.)?motherName\.last$/i.test(directive);
+}
+
+export function canonicalDirectiveForTarget(directiveKey: string, targetName?: unknown): string {
+  const trimmed = directiveKey.trim();
+  const lastColon = trimmed.lastIndexOf(':');
+  const namespace = lastColon >= 0 && lastColon + 1 < trimmed.length
+    ? trimmed.slice(0, lastColon + 1)
+    : '';
+  const directive = namespace ? trimmed.slice(lastColon + 1) : trimmed;
+
+  if (isMotherMaidenTarget(targetName) && isMotherLastDirective(directive)) {
+    return `${namespace}${directive.toLowerCase().startsWith('client.') ? 'client.' : ''}motherName.maiden`;
+  }
+  return trimmed;
 }
 
 /** Full name for a profile scope: prefer structured currentName, else firstName/lastName. */
@@ -212,61 +244,60 @@ export function resolveDirectiveFromProfiles(
   profiles: ResolvedProfiles | null | undefined,
 ): unknown {
   if (!profiles) return undefined;
-  const lower = directive.trim().toLowerCase();
+  const normalizedDirective = stripDirectiveNamespace(directive);
+  const lower = normalizedDirective.toLowerCase();
 
-  const dobMatch = directive.trim().match(/^(client|worker|director)\.\$dob_mm\/dd\/yyyy$/i);
+  const dobMatch = normalizedDirective.match(/^(client|worker|director)\.\$dob_mm\/dd\/yyyy$/i);
   if (dobMatch) {
     const profileKey = dobMatch[1].toLowerCase() as 'client' | 'worker' | 'director';
     const profile = profiles[profileKey];
     return normalizeDateLikeValue(getByPath(profile as Record<string, unknown> | undefined, 'birthDate'));
   }
-  const ageMatch = directive.trim().match(/^(client|worker|director)\.\$age$/i);
+  const ageMatch = normalizedDirective.match(/^(client|worker|director)\.\$age$/i);
   if (ageMatch) {
     const profileKey = ageMatch[1].toLowerCase() as 'client' | 'worker' | 'director';
     return computeAgeFromBirthDate(profiles[profileKey] as Record<string, unknown> | undefined);
   }
-  const monthNumberMatch = directive.trim().match(/^(client|worker|director)\.\$(birthMonth|dobMonthNumber)$/i);
+  const monthNumberMatch = normalizedDirective.match(/^(client|worker|director)\.\$(birthMonth|dobMonthNumber)$/i);
   if (monthNumberMatch) {
     const profileKey = monthNumberMatch[1].toLowerCase() as 'client' | 'worker' | 'director';
     return computeBirthMonthNumber(profiles[profileKey] as Record<string, unknown> | undefined);
   }
-  const phoneLast7Match = directive
-    .trim()
+  const phoneLast7Match = normalizedDirective
     .match(/^(client|worker|director)\.\$?(phoneLast7|phoneLastSeven|primaryPhoneLast7|primaryPhoneLastSeven|primaryPhoneNumber|primaryPhoneLocalNumber)$/i);
   if (phoneLast7Match) {
     const profileKey = phoneLast7Match[1].toLowerCase() as 'client' | 'worker' | 'director';
     return computePhoneLast7(profiles[profileKey] as Record<string, unknown> | undefined);
   }
 
-  const fullNameMatch = directive.trim().match(/^(client|worker|director)\.\$fullName$/i);
+  const fullNameMatch = normalizedDirective.match(/^(client|worker|director)\.\$fullName$/i);
   if (fullNameMatch) {
     const profileKey = fullNameMatch[1].toLowerCase() as 'client' | 'worker' | 'director';
     return computeFullName(profiles[profileKey] as Record<string, unknown> | undefined);
   }
 
-  const birthYearMatch = directive.trim().match(/^(client|worker|director)\.\$birthYear$/i);
+  const birthYearMatch = normalizedDirective.match(/^(client|worker|director)\.\$birthYear$/i);
   if (birthYearMatch) {
     const profileKey = birthYearMatch[1].toLowerCase() as 'client' | 'worker' | 'director';
     const birthDate = parseBirthDate(getByPath(profiles[profileKey] as Record<string, unknown> | undefined, 'birthDate'));
     return birthDate ? String(birthDate.getFullYear()) : undefined;
   }
 
-  const birthDayMatch = directive.trim().match(/^(client|worker|director)\.\$birthDay$/i);
+  const birthDayMatch = normalizedDirective.match(/^(client|worker|director)\.\$birthDay$/i);
   if (birthDayMatch) {
     const profileKey = birthDayMatch[1].toLowerCase() as 'client' | 'worker' | 'director';
     const birthDate = parseBirthDate(getByPath(profiles[profileKey] as Record<string, unknown> | undefined, 'birthDate'));
     return birthDate ? String(birthDate.getDate()) : undefined;
   }
 
-  if (/^(client|worker|director|org)\.\$date$/i.test(directive.trim())) {
+  if (/^(client|worker|director|org)\.\$date$/i.test(normalizedDirective)) {
     const d = new Date();
     const mm = String(d.getMonth() + 1).padStart(2, '0');
     const dd = String(d.getDate()).padStart(2, '0');
     return `${mm}/${dd}/${d.getFullYear()}`;
   }
 
-  const phonePartMatch = directive
-    .trim()
+  const phonePartMatch = normalizedDirective
     .match(/^(client|worker|director)\.\$primaryPhone(AreaCode|TelephonePrefix|LineNumber)$/i);
   if (phonePartMatch) {
     const profileKey = phonePartMatch[1].toLowerCase() as 'client' | 'worker' | 'director';
@@ -280,8 +311,7 @@ export function resolveDirectiveFromProfiles(
     return computePhonePart(profiles[profileKey] as Record<string, unknown> | undefined, part);
   }
 
-  const fullAddrMatch = directive
-    .trim()
+  const fullAddrMatch = normalizedDirective
     .match(/^(client|worker|director|org)\.\$full(PersonalAddress|MailAddress|Address)$/i);
   if (fullAddrMatch) {
     const profileKey = fullAddrMatch[1].toLowerCase() as 'client' | 'worker' | 'director' | 'org';
@@ -293,19 +323,19 @@ export function resolveDirectiveFromProfiles(
     return computeFullAddress(profile, ['personalAddress', 'mailAddress']);
   }
 
-  const addressLine1And2 = resolveAddressLine1And2Directive(directive, profiles);
+  const addressLine1And2 = resolveAddressLine1And2Directive(normalizedDirective, profiles);
   if (addressLine1And2 !== undefined) {
     return addressLine1And2;
   }
 
   if (lower.startsWith('client.') && profiles.client) {
-    return normalizeDateLikeValue(resolveProfilePath(profiles.client, directive.slice(7)));
+    return normalizeDateLikeValue(resolveProfilePath(profiles.client, normalizedDirective.slice(7)));
   }
   if (lower.startsWith('worker.') && profiles.worker) {
-    return normalizeDateLikeValue(resolveProfilePath(profiles.worker, directive.slice(7)));
+    return normalizeDateLikeValue(resolveProfilePath(profiles.worker, normalizedDirective.slice(7)));
   }
   if (lower.startsWith('org.') && profiles.org) {
-    const orgPath = directive.slice(4);
+    const orgPath = normalizedDirective.slice(4);
     const orgAlias: Record<string, string> = {
       organizationName: 'name',
       phoneNumber: 'phone',
@@ -313,7 +343,7 @@ export function resolveDirectiveFromProfiles(
     return normalizeDateLikeValue(getByPath(profiles.org, orgAlias[orgPath] ?? orgPath));
   }
   if (lower.startsWith('director.') && profiles.director) {
-    return normalizeDateLikeValue(resolveProfilePath(profiles.director, directive.slice(9)));
+    return normalizeDateLikeValue(resolveProfilePath(profiles.director, normalizedDirective.slice(9)));
   }
   if (lower === 'anydate' || lower === 'currentdate') {
     const d = new Date();
@@ -323,6 +353,14 @@ export function resolveDirectiveFromProfiles(
     return `${mm}/${dd}/${yyyy}`;
   }
   return undefined;
+}
+
+export function resolveDirectiveFromProfilesForTarget(
+  directive: string,
+  profiles: ResolvedProfiles | null | undefined,
+  targetName?: unknown,
+): unknown {
+  return resolveDirectiveFromProfiles(canonicalDirectiveForTarget(directive, targetName), profiles);
 }
 
 const NAME_HISTORY_DIRECTIVE_RE = /^nameHistory\.\d+\.(first|middle|last|suffix|maiden)$/;


### PR DESCRIPTION
## Summary
- Fix mother-maiden autofill so legacy `motherName.last` directives fill maiden-name targets from `motherName.maiden` instead of the mother's married/current last name.
- Keep the inline document upload notification flow to one SMS to the client, matching server-next's current SMS-only notification contract.
- Remove the stray `Profile` source label from client notes.
- Stop legacy/freeform client notes from being stamped with today's date on every render; undated notes now stay under a stable `Undated notes` group.
- Fix hidden PDF autofill checkboxes so captured picker values still submit `true`, letting the server apply the PDF checkbox's actual on-value.

## Verification
- `npx vitest run src/utils/directives.test.ts src/components/InteractiveForms/useInteractiveForm.test.ts`
- `npx vitest run src/components/InteractiveForms/useInteractiveForm.test.ts`
- `npx eslint src/utils/directives.ts src/utils/directives.test.ts src/components/InteractiveForms/useInteractiveForm.ts src/components/InteractiveForms/useInteractiveForm.test.ts src/components/InteractiveForms/InteractiveFormWizard.tsx src/components/Profile/ClientTimelineSection.tsx src/components/Documents/DocumentsInlineUpload.tsx`
- `npx eslint src/components/Profile/ClientTimelineSection.tsx`
- `npx eslint src/components/InteractiveForms/InteractiveFormWizard.tsx src/components/InteractiveForms/useInteractiveForm.test.ts`
- `npm run build`

## Screenshots
- Not included; changes are targeted logic/copy fixes with no layout redesign.

## Notes
- Server companion PR: https://github.com/keepid/keepid_server_next/pull/89
- Full `npm run lint:ts` still fails on pre-existing unrelated lint issues in `MailModal.tsx`, `InstallPromptContainer.tsx`, and `SignAndDownloadViewer.tsx`; the touched-file ESLint command above passes.
