### PR TITLE
Fix PDF widget text sizing

### DIFF
--- a/src/components/InteractiveForms/sign-and-download-viewer.css
+++ b/src/components/InteractiveForms/sign-and-download-viewer.css
@@ -41,11 +41,8 @@
 }
 
 /*
- * pdf.js sizes widget text from PDF rect height / DA; shallow rects yield unreadably small inputs.
- * When HTML widgets are active, enforce a minimum readable size (inline fontSize still uses --total-scale-factor).
+ * Keep PDF widget typography under pdf.js control. The annotation layer derives
+ * text sizing from the PDF field appearance/default appearance and page scale;
+ * app-level font-size/line-height overrides can double-scale text and clip it
+ * inside fixed PDF field rectangles.
  */
-.keepid-pdf-preview.keepid-pdf-form-widgets-active .annotationLayer .textWidgetAnnotation :is(input, textarea),
-.keepid-pdf-preview.keepid-pdf-form-widgets-active .annotationLayer .choiceWidgetAnnotation select {
-  font-size: max(calc(11px * var(--total-scale-factor)), 13px) !important;
-  line-height: 1.25 !important;
-}


### PR DESCRIPTION
## Summary
- Remove the custom app-level font-size and line-height override for PDF form widgets in the embedded application PDF viewer.
- Let pdf.js derive text sizing from the PDF field appearance/default appearance and page scale, matching native Chrome PDF rendering more closely.

## Verification
- `npm ci`
- `npm run build`
- `git diff --check`

## Screenshots
- Not captured. The root cause was CSS overriding pdf.js widget typography; Chrome native PDF preview already showed the PDF bytes rendering correctly.

## Notes
- Root cause: the embedded viewer forced `font-size: max(calc(11px * var(--total-scale-factor)), 13px)` and `line-height: 1.25` on annotation-layer inputs. In fixed PDF field rectangles, that can double-scale/clamp text and make values look clipped even when the PDF itself is fine.
