### PR TITLE
Fix PDF read-only preview field rendering

### DIFF
--- a/src/components/InteractiveForms/SignAndDownloadViewer.tsx
+++ b/src/components/InteractiveForms/SignAndDownloadViewer.tsx
@@ -198,10 +198,11 @@ const SignAndDownloadViewer = React.forwardRef<SignAndDownloadViewerHandle, Sign
   const pdfWidgetsEditable = !pdfFormsReadOnly || (showPdfEditControls && isPdfEditMode);
   const effectivePdfFormsReadOnly = !pdfWidgetsEditable;
   /*
-   * Render pdf.js form widgets only while the PDF is editable. Read-only
-   * preview should show the PDF's own rendered appearance, not HTML inputs.
+   * Keep pdf.js in charge of AcroForm widget layout in both edit and
+   * read-only preview. The PDF's saved appearance streams can be stale or
+   * vertically clipped; pdf.js reads the current form values directly.
    */
-  const renderPdfFormWidgets = pdfWidgetsEditable;
+  const renderPdfFormWidgets = true;
 
   const signedCount = embeddedBoxes.size;
   const allSigned = signaturePlacements.length === 0 || signedCount === signaturePlacements.length;

--- a/src/components/InteractiveForms/sign-and-download-viewer.css
+++ b/src/components/InteractiveForms/sign-and-download-viewer.css
@@ -40,6 +40,24 @@
   pointer-events: none;
 }
 
+.keepid-pdf-preview.keepid-pdf-edit-locked.keepid-pdf-form-widgets-active
+  .annotationLayer
+  :is(.textWidgetAnnotation, .choiceWidgetAnnotation)
+  :is(input, textarea, select) {
+  background: transparent !important;
+  border-color: transparent !important;
+  box-shadow: none !important;
+  outline: none !important;
+  caret-color: transparent;
+}
+
+.keepid-pdf-preview.keepid-pdf-edit-locked.keepid-pdf-form-widgets-active
+  .annotationLayer
+  .choiceWidgetAnnotation
+  select {
+  appearance: none;
+}
+
 /*
  * Keep PDF widget typography under pdf.js control. The annotation layer derives
  * text sizing from the PDF field appearance/default appearance and page scale;


### PR DESCRIPTION
## Summary
- Render pdf.js AcroForm widgets in read-only preview so preview uses current field values instead of stale/clipped PDF appearance streams.
- Strip input/select chrome in read-only mode so the widgets appear like plain PDF text instead of blue boxes.

## Verification
- `npm ci` (completed; npm warned local Node v25.9.0 does not match required 22.14.0)
- `npm run build`
- `npm run lint:ts` (not clean; existing lint failures remain in `MailModal.tsx`, `InstallPromptContainer.tsx`, and existing `SignAndDownloadViewer.tsx` lint rules around import sorting / `continue` statements)

## Screenshots
- Not captured; this is a PDF rendering path and the relevant regression needs a live application PDF/session.

## Notes
- This fixes preview only. The companion server PR fixes print/download flattening so both rendering paths stop relying on clipped AcroForm appearance streams.
