### PR TITLE
Fix profile phone number editing focus

### DIFF
--- a/src/components/Profile/EssentialAccountSection.test.tsx
+++ b/src/components/Profile/EssentialAccountSection.test.tsx
@@ -1,0 +1,63 @@
+/* @vitest-environment jsdom */
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+import EssentialAccountSection from './EssentialAccountSection';
+import type { ProfileData } from './ProfilePage';
+
+vi.mock('react-alert', () => ({
+  useAlert: () => ({
+    show: vi.fn(),
+  }),
+}));
+
+vi.mock('../../serverOverride', () => ({
+  default: () => 'http://localhost:7001',
+}));
+
+const profile: ProfileData = {
+  username: 'demo-client',
+  firstName: 'Demo',
+  lastName: 'Client',
+  email: 'demo@example.org',
+};
+
+describe('EssentialAccountSection', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps focus in an edited phone number input after the phone value changes', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      json: async () => ({
+        status: 'SUCCESS',
+        phoneBook: [
+          { label: 'primary', phoneNumber: '2155550100' },
+        ],
+      }),
+    })));
+
+    render(<EssentialAccountSection profile={profile} />);
+
+    await screen.findByText('(215) 555 - 0100');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const phoneInput = screen.getByPlaceholderText('Phone number');
+    phoneInput.focus();
+
+    fireEvent.change(phoneInput, { target: { value: '21555501008' } });
+
+    expect(screen.getByDisplayValue('21555501008')).toHaveFocus();
+  });
+});

--- a/src/components/Profile/EssentialAccountSection.tsx
+++ b/src/components/Profile/EssentialAccountSection.tsx
@@ -17,6 +17,11 @@ type PhoneBookEntry = {
   phoneNumber: string;
 };
 
+type EditablePhoneBookEntry = PhoneBookEntry & {
+  originalPhoneNumber: string;
+  rowKey: string;
+};
+
 const PRIMARY_LABEL = 'primary';
 
 type Props = {
@@ -102,6 +107,14 @@ function formatAddress(address: AddressObj | undefined): string {
   return [street, cityStateZip, county].filter(Boolean).join('\n');
 }
 
+function editablePhoneBookFrom(entries: PhoneBookEntry[]): EditablePhoneBookEntry[] {
+  return entries.map((entry, index) => ({
+    ...entry,
+    originalPhoneNumber: entry.phoneNumber,
+    rowKey: `${index}-${entry.label}-${entry.phoneNumber}`,
+  }));
+}
+
 function CopyButton({
   label,
   value,
@@ -152,7 +165,7 @@ export default function EssentialAccountSection({
 
   const [phoneBook, setPhoneBook] = useState<PhoneBookEntry[]>([]);
   const [phoneBookLoading, setPhoneBookLoading] = useState(true);
-  const [editedPhoneBook, setEditedPhoneBook] = useState<PhoneBookEntry[]>([]);
+  const [editedPhoneBook, setEditedPhoneBook] = useState<EditablePhoneBookEntry[]>([]);
   const [addLabel, setAddLabel] = useState('');
   const [addPhone, setAddPhone] = useState('');
   const [showAddRow, setShowAddRow] = useState(false);
@@ -178,7 +191,7 @@ export default function EssentialAccountSection({
       const json = await res.json();
       if (json.status === 'SUCCESS' && Array.isArray(json.phoneBook)) {
         setPhoneBook(json.phoneBook);
-        setEditedPhoneBook(json.phoneBook.map((e: PhoneBookEntry) => ({ ...e })));
+        setEditedPhoneBook(editablePhoneBookFrom(json.phoneBook));
       }
     } catch {
       // silent
@@ -193,9 +206,11 @@ export default function EssentialAccountSection({
 
   const phoneBookDirty = useMemo(() => {
     if (editedPhoneBook.length !== phoneBook.length) return true;
-    return editedPhoneBook.some((e, i) => {
-      const orig = phoneBook[i];
-      return e.label !== orig.label || e.phoneNumber !== orig.phoneNumber;
+    return editedPhoneBook.some((entry) => {
+      const orig = phoneBook.find((phoneBookEntry) => (
+        phoneBookEntry.phoneNumber === entry.originalPhoneNumber
+      ));
+      return !orig || entry.label !== orig.label || entry.phoneNumber !== orig.phoneNumber;
     });
   }, [editedPhoneBook, phoneBook]);
 
@@ -260,8 +275,12 @@ export default function EssentialAccountSection({
     }
 
     const edits = editedPhoneBook
-      .map((edited, i) => ({ edited, orig: phoneBook[i] }))
-      .filter(({ edited, orig }) => {
+      .map((edited) => ({
+        edited,
+        orig: phoneBook.find((entry) => entry.phoneNumber === edited.originalPhoneNumber),
+      }))
+      .filter((change): change is { edited: EditablePhoneBookEntry; orig: PhoneBookEntry } => {
+        const { edited, orig } = change;
         if (!orig) return false;
         return edited.label !== orig.label || edited.phoneNumber !== orig.phoneNumber;
       });
@@ -288,9 +307,9 @@ export default function EssentialAccountSection({
       }
     }
 
-    const editedPhones = new Set(editedPhoneBook.map((e) => e.phoneNumber));
+    const editedOriginalPhones = new Set(editedPhoneBook.map((e) => e.originalPhoneNumber));
     const deletions = phoneBook.filter(
-      (orig) => !editedPhones.has(orig.phoneNumber) && orig.label.toLowerCase() !== PRIMARY_LABEL,
+      (orig) => !editedOriginalPhones.has(orig.phoneNumber) && orig.label.toLowerCase() !== PRIMARY_LABEL,
     );
 
     // eslint-disable-next-line no-restricted-syntax
@@ -460,7 +479,7 @@ export default function EssentialAccountSection({
 
   function beginEdit() {
     setEmail(initialEmail);
-    setEditedPhoneBook(phoneBook.map((e) => ({ ...e })));
+    setEditedPhoneBook(editablePhoneBookFrom(phoneBook));
     setEditMailAddress(initialAddressFromProfile(profile));
     setShowAddRow(false);
     setAddLabel('');
@@ -486,7 +505,7 @@ export default function EssentialAccountSection({
   function cancelEdit() {
     if (isDirty && !window.confirm('Discard unsaved changes?')) return;
     setEmail(initialEmail);
-    setEditedPhoneBook(phoneBook.map((e) => ({ ...e })));
+    setEditedPhoneBook(editablePhoneBookFrom(phoneBook));
     setEditMailAddress(initialAddressFromProfile(profile));
     setShowAddRow(false);
     setAddLabel('');
@@ -761,7 +780,7 @@ export default function EssentialAccountSection({
                 {editedPhoneBook.map((entry, i) => {
                   const isPrimary = entry.label.toLowerCase() === PRIMARY_LABEL;
                   return (
-                    <div key={`${entry.phoneNumber}-${entry.label}`} className="tw-flex tw-items-center tw-gap-2">
+                    <div key={entry.rowKey} className="tw-flex tw-items-center tw-gap-2">
                       {isPrimary ? (
                         <span className="form-control form-purple tw-bg-gray-100 tw-text-gray-500" style={{ maxWidth: 160 }}>
                           {entry.label}


### PR DESCRIPTION
## Summary
- Keep profile phone-book edit rows keyed by a stable local row id instead of the mutable phone number and label.
- Track the original phone number separately so edits and deletions are matched to the correct saved entry.
- Add a regression test that verifies the edited phone input keeps focus after its value changes.

## Verification
- `npx vitest run`
- `npm run build`
- `npx eslint src/components/Profile/EssentialAccountSection.tsx src/components/Profile/EssentialAccountSection.test.tsx --ext .tsx` (passes with existing `react/jsx-no-bind` warnings in `EssentialAccountSection.tsx`)
- `npm run lint:ts` (fails on existing unrelated errors in `src/components/Documents/MailModal.tsx` and `src/components/InstallPrompt/InstallPromptContainer.tsx`)

## Screenshots
- Not included; this fixes input focus behavior without a visual change.

## Notes
- Draft PR for review.