### PR TITLE
Fix PDF checkbox option tokens

### DIFF
--- a/src/components/InteractiveForms/InteractiveFormWizard.tsx
+++ b/src/components/InteractiveForms/InteractiveFormWizard.tsx
@@ -18,7 +18,7 @@ export function applyAutoFillFields(
   autoFillFields.forEach((af) => {
     if (!af.pdfFieldName) return;
     if (af.fieldType === 'checkbox') {
-      merged[af.pdfFieldName] = 'true';
+      merged[af.pdfFieldName] = typeof af.value === 'string' && af.value.trim() !== '' ? af.value : 'true';
       return;
     }
     let val: unknown;

--- a/src/components/InteractiveForms/InteractiveFormWizard.tsx
+++ b/src/components/InteractiveForms/InteractiveFormWizard.tsx
@@ -6,7 +6,7 @@ import { normalizeDateLikeValue, resolveDirectiveFromProfilesForTarget } from '.
 import { WizardSubmitProvider } from './InteractiveFormWizardContext';
 import { interactiveFormCells, interactiveFormRenderers } from './renderers';
 import { type AutoFillField, type BuilderState, type OutputFieldDefinition, computeMetadata } from './types';
-import { extractDirectivesFromUiSchema, useInteractiveForm } from './useInteractiveForm';
+import { extractDirectivesFromUiSchema, normalizeTextFieldValues, useInteractiveForm } from './useInteractiveForm';
 
 export function applyAutoFillFields(
   pdfFill: Record<string, unknown>,
@@ -75,16 +75,16 @@ export default function InteractiveFormWizard({
   React.useEffect(() => {
     if (!loading && uiSchema && resolvedProfiles) {
       if (initialData && Object.keys(initialData).length > 0 && !hasAppliedInitialData.current) {
-        setData(initialData);
+        setData(normalizeTextFieldValues(initialData, jsonSchema));
         hasAppliedInitialData.current = true;
       } else if (!initialData || Object.keys(initialData).length === 0) {
         if (lastApplicationId.current !== applicationId) {
           lastApplicationId.current = applicationId;
-          setData(getInitialData());
+          setData(normalizeTextFieldValues(getInitialData(), jsonSchema));
         }
       }
     }
-  }, [loading, uiSchema, resolvedProfiles, getInitialData, applicationId, initialData]);
+  }, [loading, uiSchema, resolvedProfiles, getInitialData, applicationId, initialData, jsonSchema]);
   const effectiveOutputFields = outputFields ?? builderState?.outputFields;
   const effectiveAutoFillFields = autoFillFields ?? builderState?.autoFillFields;
 
@@ -96,13 +96,15 @@ export default function InteractiveFormWizard({
   }, [data, getFormAnswers, jsonSchema, uiSchema, onDebugUpdate, effectiveAutoFillFields, resolvedProfiles]);
 
   const requestSubmit = useCallback(() => {
-    const baseFill = getFormAnswers(data);
+    const normalizedData = normalizeTextFieldValues(data, jsonSchema);
+    if (normalizedData !== data) setData(normalizedData);
+    const baseFill = getFormAnswers(normalizedData);
     const pdfFill = applyAutoFillFields(baseFill, effectiveAutoFillFields, resolvedProfiles);
-    const metadata = computeMetadata(effectiveOutputFields, data, { pdfFill, resolvedProfiles: resolvedProfiles ?? undefined });
-    const profileUpdates = uiSchema ? extractDirectivesFromUiSchema(uiSchema as Record<string, unknown>, data) : {};
+    const metadata = computeMetadata(effectiveOutputFields, normalizedData, { pdfFill, resolvedProfiles: resolvedProfiles ?? undefined });
+    const profileUpdates = uiSchema ? extractDirectivesFromUiSchema(uiSchema as Record<string, unknown>, normalizedData, jsonSchema) : {};
     const formOutput = { ...pdfFill, metadata };
-    onSubmit(pdfFill, formOutput, data, profileUpdates);
-  }, [data, getFormAnswers, effectiveOutputFields, effectiveAutoFillFields, onSubmit, resolvedProfiles, uiSchema]);
+    onSubmit(pdfFill, formOutput, normalizedData, profileUpdates);
+  }, [data, getFormAnswers, effectiveOutputFields, effectiveAutoFillFields, onSubmit, resolvedProfiles, uiSchema, jsonSchema]);
 
   if (loading) {
     return (
@@ -138,7 +140,7 @@ export default function InteractiveFormWizard({
           renderers={interactiveFormRenderers}
           cells={interactiveFormCells}
           onChange={({ data: newData }) => {
-            if (newData != null) setData(newData);
+            if (newData != null) setData(normalizeTextFieldValues(newData, jsonSchema));
           }}
         />
       </div>

--- a/src/components/InteractiveForms/useInteractiveForm.test.ts
+++ b/src/components/InteractiveForms/useInteractiveForm.test.ts
@@ -140,6 +140,7 @@ describe('interactive form PDF fill directives', () => {
       { pdfFieldName: 'fixedClientPhoneArea', valueSource: 'directive', value: 'client.$primaryPhoneAreaCode' },
       { pdfFieldName: 'fixedLiteral', valueSource: 'literal', value: 'Static outcome' },
       { pdfFieldName: 'fixedCheckbox', valueSource: 'literal', value: 'Choice2', fieldType: 'checkbox' },
+      { pdfFieldName: 'fixedDefaultCheckbox', valueSource: 'literal', value: '', fieldType: 'checkbox' },
     ];
 
     expect(applyAutoFillFields(baseFill, autoFillFields, resolvedProfiles as Record<string, unknown>)).toEqual({
@@ -149,7 +150,8 @@ describe('interactive form PDF fill directives', () => {
       fixedDirectorBirthYear: '1918',
       fixedClientPhoneArea: '215',
       fixedLiteral: 'Static outcome',
-      fixedCheckbox: 'true',
+      fixedCheckbox: 'Choice2',
+      fixedDefaultCheckbox: 'true',
     });
   });
 

--- a/src/components/InteractiveForms/useInteractiveForm.test.ts
+++ b/src/components/InteractiveForms/useInteractiveForm.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { ResolvedProfiles } from '../../utils/directives';
 import { applyAutoFillFields } from './InteractiveFormWizard';
 import type { AutoFillField } from './types';
-import { buildFormAnswers, extractDirectivesFromUiSchema } from './useInteractiveForm';
+import { buildFormAnswers, extractDirectivesFromUiSchema, normalizeTextFieldValues } from './useInteractiveForm';
 
 const resolvedProfiles: ResolvedProfiles = {
   client: {
@@ -53,6 +53,10 @@ const jsonSchema = {
     dateQuestion: { type: 'string' },
     literalCheckbox: { type: 'boolean' },
     choice: { type: 'string' },
+    firstName: { type: 'string' },
+    streetAddress: { type: 'string' },
+    emailAddress: { type: 'string', format: 'email' },
+    appointmentDate: { type: 'string', format: 'date' },
   },
 };
 
@@ -101,6 +105,73 @@ describe('interactive form PDF fill directives', () => {
     });
 
     vi.useRealTimers();
+  });
+
+  it('title-cases free-text renderer answers while preserving email, date, and choice values', () => {
+    expect(
+      normalizeTextFieldValues(
+        {
+          firstName: 'daniel',
+          streetAddress: '1030 douglas street apt 2b',
+          emailAddress: 'daniel@example.com',
+          appointmentDate: '2026-07-02',
+          choice: 'replacement',
+        },
+        {
+          ...jsonSchema,
+          properties: {
+            ...jsonSchema.properties,
+            choice: { type: 'string', enum: ['replacement', 'original'] },
+          },
+        },
+      ),
+    ).toEqual({
+      firstName: 'Daniel',
+      streetAddress: '1030 Douglas Street Apt 2B',
+      emailAddress: 'daniel@example.com',
+      appointmentDate: '2026-07-02',
+      choice: 'replacement',
+    });
+  });
+
+  it('sends title-cased free-text answers to PDF fill fields', () => {
+    const uiSchema = {
+      type: 'VerticalLayout',
+      elements: [
+        {
+          type: 'Control',
+          scope: '#/properties/firstName',
+          options: { pdfField: 'first_name' },
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/streetAddress',
+          options: { pdfField: 'address_line_1' },
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/emailAddress',
+          options: { pdfField: 'email' },
+        },
+      ],
+    };
+
+    expect(
+      buildFormAnswers(
+        uiSchema,
+        jsonSchema,
+        {
+          firstName: 'daniel',
+          streetAddress: '1030 douglas street',
+          emailAddress: 'daniel@example.com',
+        },
+        resolvedProfiles,
+      ),
+    ).toEqual({
+      first_name: 'Daniel',
+      address_line_1: '1030 Douglas Street',
+      email: 'daniel@example.com',
+    });
   });
 
   it('preserves fixed literal outcomes for boolean and option annotations', () => {
@@ -215,6 +286,37 @@ describe('interactive form PDF fill directives', () => {
 
     expect(extractDirectivesFromUiSchema(uiSchema, { motherMaiden: 'Milbanke' })).toEqual({
       'client.motherName.maiden': 'Milbanke',
+    });
+  });
+
+  it('syncs title-cased free-text answers back to profile directives', () => {
+    const uiSchema = {
+      type: 'VerticalLayout',
+      elements: [
+        {
+          type: 'Control',
+          label: 'Street address',
+          scope: '#/properties/streetAddress',
+          options: { directive: 'client.personalAddress.line1' },
+        },
+        {
+          type: 'Control',
+          label: 'Email',
+          scope: '#/properties/emailAddress',
+          options: { directive: 'client.email' },
+        },
+      ],
+    };
+
+    expect(
+      extractDirectivesFromUiSchema(
+        uiSchema,
+        { streetAddress: '1030 douglas street', emailAddress: 'daniel@example.com' },
+        jsonSchema,
+      ),
+    ).toEqual({
+      'client.personalAddress.line1': '1030 Douglas Street',
+      'client.email': 'daniel@example.com',
     });
   });
 });

--- a/src/components/InteractiveForms/useInteractiveForm.test.ts
+++ b/src/components/InteractiveForms/useInteractiveForm.test.ts
@@ -289,6 +289,31 @@ describe('interactive form PDF fill directives', () => {
     });
   });
 
+  it('syncs parent-name alias directives back to canonical profile paths', () => {
+    const uiSchema = {
+      type: 'VerticalLayout',
+      elements: [
+        {
+          type: 'Control',
+          label: "Mother's maiden name",
+          scope: '#/properties/motherMaiden',
+          options: { directive: 'client.mother.name.last' },
+        },
+        {
+          type: 'Control',
+          label: "Father's last name",
+          scope: '#/properties/fatherLast',
+          options: { directive: 'client.father.name.last' },
+        },
+      ],
+    };
+
+    expect(extractDirectivesFromUiSchema(uiSchema, { motherMaiden: 'Milbanke', fatherLast: 'Byron' })).toEqual({
+      'client.motherName.maiden': 'Milbanke',
+      'client.fatherName.last': 'Byron',
+    });
+  });
+
   it('syncs title-cased free-text answers back to profile directives', () => {
     const uiSchema = {
       type: 'VerticalLayout',

--- a/src/components/InteractiveForms/useInteractiveForm.ts
+++ b/src/components/InteractiveForms/useInteractiveForm.ts
@@ -71,6 +71,84 @@ function formatDateForPdf(value: unknown): unknown {
   return value;
 }
 
+const NON_TITLE_CASE_FORMATS = new Set(['date', 'date-time', 'email', 'time', 'uri', 'url', 'uuid']);
+
+function getScopePath(scope: string): string {
+  return scope.replace('#/properties/', '').replace(/\//g, '.');
+}
+
+function getSchemaForPath(
+  jsonSchema: Record<string, unknown> | null | undefined,
+  propPath: string,
+): Record<string, unknown> | undefined {
+  const props = jsonSchema?.properties as Record<string, unknown> | undefined;
+  const direct = props?.[propPath];
+  if (direct && typeof direct === 'object') return direct as Record<string, unknown>;
+  return propPath.split('.').reduce<Record<string, unknown> | undefined>((schema, part) => {
+    const nestedProps = schema?.properties as Record<string, unknown> | undefined;
+    const next = nestedProps?.[part];
+    return next && typeof next === 'object' ? next as Record<string, unknown> : undefined;
+  }, jsonSchema);
+}
+
+function isTitleCaseTextSchema(schema: Record<string, unknown> | undefined): boolean {
+  if (!schema) return false;
+  if (schema.type !== 'string') return false;
+  if (Array.isArray(schema.enum)) return false;
+  const format = typeof schema.format === 'string' ? schema.format.toLowerCase() : '';
+  return !NON_TITLE_CASE_FORMATS.has(format);
+}
+
+function shouldSkipTitleCaseValue(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return true;
+  if (!/\p{L}/u.test(trimmed)) return true;
+  if (trimmed.includes('@')) return true;
+  if (/^(?:https?:\/\/|www\.)/i.test(trimmed)) return true;
+  if (trimmed.includes('_')) return true;
+  return false;
+}
+
+export function titleCaseTextFieldValue(value: string): string {
+  if (shouldSkipTitleCaseValue(value)) return value;
+  return value.replace(/\p{L}[\p{L}'-]*/gu, (word) => (
+    word
+      .toLocaleLowerCase()
+      .replace(/(^|['-])(\p{L})/gu, (_match, prefix: string, letter: string) => (
+        `${prefix}${letter.toLocaleUpperCase()}`
+      ))
+  ));
+}
+
+function formatTextValue(value: unknown, shouldTitleCase: boolean): unknown {
+  if (!shouldTitleCase || typeof value !== 'string') return value;
+  return titleCaseTextFieldValue(value);
+}
+
+function formatValueForPdf(value: unknown, shouldTitleCase: boolean): unknown {
+  return formatTextValue(formatDateForPdf(value), shouldTitleCase);
+}
+
+export function normalizeTextFieldValues(
+  data: Record<string, unknown>,
+  jsonSchema: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  const props = jsonSchema?.properties as Record<string, unknown> | undefined;
+  if (!props) return data;
+
+  let next: Record<string, unknown> | null = null;
+  Object.entries(props).forEach(([key, schema]) => {
+    if (!isTitleCaseTextSchema(schema as Record<string, unknown> | undefined)) return;
+    const current = data[key];
+    if (typeof current !== 'string') return;
+    const formatted = titleCaseTextFieldValue(current);
+    if (formatted === current) return;
+    if (!next) next = { ...data };
+    next[key] = formatted;
+  });
+  return next ?? data;
+}
+
 function resolveConditionalDirective(
   directiveArray: Array<{ when?: { scope?: string; schema?: Record<string, unknown> }; use: string }>,
   data: Record<string, unknown>,
@@ -95,14 +173,15 @@ export function buildFormAnswers(
   const ON_PLACEHOLDER = 'On';
 
   function getPropValue(scope: string): unknown {
-    const propPath = scope.replace('#/properties/', '').replace(/\//g, '.');
-    return getByPath(data, propPath);
+    return getByPath(data, getScopePath(scope));
   }
 
   function isBooleanScope(scope: string): boolean {
-    const propPath = scope.replace('#/properties/', '').replace(/\//g, '.');
-    const props = (jsonSchema.properties as Record<string, { type?: unknown }> | undefined) ?? {};
-    return props[propPath]?.type === 'boolean';
+    return getSchemaForPath(jsonSchema, getScopePath(scope))?.type === 'boolean';
+  }
+
+  function isTitleCaseTextScope(scope: string): boolean {
+    return isTitleCaseTextSchema(getSchemaForPath(jsonSchema, getScopePath(scope)));
   }
 
   function processElement(element: Record<string, unknown>) {
@@ -147,8 +226,9 @@ export function buildFormAnswers(
             out[pdfField] = token;
           }
         } else if (value !== undefined && value !== null && value !== '') {
-          if (options.fillValue !== undefined && options.fillValue !== null) value = options.fillValue;
-          out[pdfField] = formatDateForPdf(value);
+          const hasExplicitFill = options.fillValue !== undefined && options.fillValue !== null;
+          if (hasExplicitFill) value = options.fillValue;
+          out[pdfField] = formatValueForPdf(value, isTitleCaseTextScope(scope) && !hasExplicitFill);
         }
       }
 
@@ -214,7 +294,8 @@ export function buildFormAnswers(
             )
             : baseValue);
           if (fillVal !== undefined && fillVal !== null && fillVal !== '') {
-            out[pdfField] = formatDateForPdf(fillVal);
+            const usesBaseValue = cf.fillValue === undefined && !(resolvedProfiles && cf.directive);
+            out[pdfField] = formatValueForPdf(fillVal, usesBaseValue && isTitleCaseTextScope(scope));
           }
         });
       }
@@ -288,7 +369,8 @@ export function buildFormAnswers(
               targetText(element.label, pdfField),
             ) : baseValue);
           if (fillVal !== undefined && fillVal !== null && fillVal !== '') {
-            out[pdfField] = formatDateForPdf(fillVal);
+            const usesBaseValue = cf.fillValue === undefined && !(cf.directive && resolvedProfiles);
+            out[pdfField] = formatValueForPdf(fillVal, usesBaseValue && isTitleCaseTextScope(firstScope));
           }
         });
       }
@@ -476,12 +558,16 @@ export function useInteractiveForm({
 export function extractDirectivesFromUiSchema(
   uiSchema: Record<string, unknown>,
   data: Record<string, unknown>,
+  jsonSchema?: Record<string, unknown> | null,
 ): Record<string, unknown> {
   const directivesMap: Record<string, unknown> = {};
 
   function getPropValue(scope: string): unknown {
-    const propPath = scope.replace('#/properties/', '').replace(/\//g, '.');
-    return getByPath(data, propPath);
+    return getByPath(data, getScopePath(scope));
+  }
+
+  function isTitleCaseTextScope(scope: string): boolean {
+    return isTitleCaseTextSchema(getSchemaForPath(jsonSchema, getScopePath(scope)));
   }
 
   function processElement(element: Record<string, unknown>) {
@@ -495,10 +581,11 @@ export function extractDirectivesFromUiSchema(
       if (scope && directive != null) {
         const value = getPropValue(scope);
         if (value !== undefined && value !== null && value !== '') {
+          const formattedValue = formatTextValue(value, isTitleCaseTextScope(scope));
           if (typeof directive === 'string') {
             const profileDirective = canonicalDirectiveForTarget(directive, targetText(element.label, scope));
             if (!isExcludedFromProfileFormSync(profileDirective)) {
-              directivesMap[profileDirective] = value;
+              directivesMap[profileDirective] = formattedValue;
             }
           } else if (Array.isArray(directive)) {
             const useDirective = resolveConditionalDirective(
@@ -509,7 +596,7 @@ export function extractDirectivesFromUiSchema(
               ? canonicalDirectiveForTarget(useDirective, targetText(element.label, scope))
               : null;
             if (profileDirective && !isExcludedFromProfileFormSync(profileDirective)) {
-              directivesMap[profileDirective] = value;
+              directivesMap[profileDirective] = formattedValue;
             }
           }
         }

--- a/src/utils/directives.test.ts
+++ b/src/utils/directives.test.ts
@@ -81,6 +81,12 @@ describe('directive resolution', () => {
     expect(resolveDirectiveFromProfiles('client.motherName.last', profiles)).toBe('Byron');
     expect(resolveDirectiveFromProfiles('client.motherName.maiden', profiles)).toBe('Milbanke');
     expect(resolveDirectiveFromProfiles('dummy:client.motherName.maiden', profiles)).toBe('Milbanke');
+    expect(resolveDirectiveFromProfiles('client.mother.name.maiden', profiles)).toBe('Milbanke');
+    expect(resolveDirectiveFromProfiles('client.motherLastName', profiles)).toBe('Byron');
+    expect(resolveDirectiveFromProfiles('client.father.name.last', profiles)).toBe('Byron');
+    expect(resolveDirectiveFromProfiles('client.fatherFirstName', profiles)).toBe('Lord');
+    expect(resolveDirectiveFromProfiles('client.emailAddress', profiles)).toBe('ada@example.org');
+    expect(resolveDirectiveFromProfiles('client.genderAssignedAtBirth', profiles)).toBe('F');
     expect(resolveDirectiveFromProfiles('worker.currentName.last', profiles)).toBe('Hopper');
     expect(resolveDirectiveFromProfiles('director.email', profiles)).toBe('kj@example.org');
   });
@@ -92,6 +98,11 @@ describe('directive resolution', () => {
       .toBe('dummy:client.motherName.maiden');
     expect(resolveDirectiveFromProfilesForTarget(
       'client.motherName.last',
+      profiles,
+      "Mother's Maiden Name",
+    )).toBe('Milbanke');
+    expect(resolveDirectiveFromProfilesForTarget(
+      'client.mother.name.last',
       profiles,
       "Mother's Maiden Name",
     )).toBe('Milbanke');

--- a/src/utils/directives.ts
+++ b/src/utils/directives.ts
@@ -103,6 +103,42 @@ function stripDirectiveNamespace(directive: string): string {
     : trimmed;
 }
 
+function splitDirectiveNamespace(directive: string): { namespace: string; path: string } {
+  const trimmed = directive.trim();
+  const lastColon = trimmed.lastIndexOf(':');
+  if (lastColon >= 0 && lastColon + 1 < trimmed.length) {
+    return { namespace: trimmed.slice(0, lastColon + 1), path: trimmed.slice(lastColon + 1) };
+  }
+  return { namespace: '', path: trimmed };
+}
+
+const DIRECTIVE_ALIASES: Record<string, string> = {
+  emailAddress: 'email',
+  genderAssignedAtBirth: 'sex',
+  motherFirstName: 'motherName.first',
+  motherMiddleName: 'motherName.middle',
+  motherLastName: 'motherName.last',
+  motherMaidenName: 'motherName.maiden',
+  fatherFirstName: 'fatherName.first',
+  fatherMiddleName: 'fatherName.middle',
+  fatherLastName: 'fatherName.last',
+  fatherMaidenName: 'fatherName.maiden',
+};
+
+function normalizeDirectiveAlias(path: string): string {
+  const scopeMatch = path.match(/^(client|worker|director|org)\.(.+)$/i);
+  const scope = scopeMatch?.[1].toLowerCase();
+  const localPath = scopeMatch?.[2] ?? path;
+  const aliasedPath = DIRECTIVE_ALIASES[localPath] ?? localPath;
+  const parentNameAlias = aliasedPath.match(/^(mother|father)(?:Name|\.name)?\.(first|middle|last|suffix|maiden)$/i);
+  if (parentNameAlias) {
+    const root = parentNameAlias[1].toLowerCase() === 'father' ? 'fatherName' : 'motherName';
+    const normalized = `${root}.${parentNameAlias[2].toLowerCase()}`;
+    return scope ? `${scope}.${normalized}` : normalized;
+  }
+  return scope ? `${scope}.${aliasedPath}` : aliasedPath;
+}
+
 function resolveProfilePath(profile: Record<string, unknown> | undefined, path: string): unknown {
   const value = getByPath(profile, path);
   if (!isBlankValue(value)) return value;
@@ -128,17 +164,13 @@ function isMotherLastDirective(directive: string): boolean {
 }
 
 export function canonicalDirectiveForTarget(directiveKey: string, targetName?: unknown): string {
-  const trimmed = directiveKey.trim();
-  const lastColon = trimmed.lastIndexOf(':');
-  const namespace = lastColon >= 0 && lastColon + 1 < trimmed.length
-    ? trimmed.slice(0, lastColon + 1)
-    : '';
-  const directive = namespace ? trimmed.slice(lastColon + 1) : trimmed;
+  const { namespace, path } = splitDirectiveNamespace(directiveKey);
+  const directive = normalizeDirectiveAlias(path);
 
   if (isMotherMaidenTarget(targetName) && isMotherLastDirective(directive)) {
     return `${namespace}${directive.toLowerCase().startsWith('client.') ? 'client.' : ''}motherName.maiden`;
   }
-  return trimmed;
+  return `${namespace}${directive}`;
 }
 
 /** Full name for a profile scope: prefer structured currentName, else firstName/lastName. */
@@ -244,7 +276,7 @@ export function resolveDirectiveFromProfiles(
   profiles: ResolvedProfiles | null | undefined,
 ): unknown {
   if (!profiles) return undefined;
-  const normalizedDirective = stripDirectiveNamespace(directive);
+  const normalizedDirective = stripDirectiveNamespace(canonicalDirectiveForTarget(directive));
   const lower = normalizedDirective.toLowerCase();
 
   const dobMatch = normalizedDirective.match(/^(client|worker|director)\.\$dob_mm\/dd\/yyyy$/i);
@@ -370,11 +402,7 @@ const NAME_HISTORY_DIRECTIVE_RE = /^nameHistory\.\d+\.(first|middle|last|suffix|
  * UpdateProfileFromFormService#isExcludedFromInteractiveFormSync).
  */
 export function isExcludedFromProfileFormSync(directiveKey: string): boolean {
-  let d = directiveKey.trim();
-  const lastColon = d.lastIndexOf(':');
-  if (lastColon >= 0 && lastColon + 1 < d.length) {
-    d = d.slice(lastColon + 1);
-  }
+  let d = stripDirectiveNamespace(canonicalDirectiveForTarget(directiveKey));
   if (d.startsWith('client.')) {
     d = d.slice('client.'.length);
   }


### PR DESCRIPTION
## Summary
- Preserve explicit checkbox PDF option tokens in hidden auto-fill mappings.
- Keep the June 29 fallback behavior that sends `true` when no token exists.
- Title-case free-text answers in the client interactive form renderer, including saved form data, PDF fill values, metadata, and profile sync output.
- Canonicalize profile directive aliases before resolving/syncing values, including parent aliases such as `client.mother.name.maiden` and legacy aliases like `client.emailAddress`.
- Update interactive form and directive unit coverage.

## Verification
- `npx vitest run src/utils/directives.test.ts src/components/InteractiveForms/useInteractiveForm.test.ts`
- `npx eslint src/utils/directives.ts src/utils/directives.test.ts src/components/InteractiveForms/useInteractiveForm.test.ts`
- `npm run build`
- `git diff --check`
- `npm run lint:ts` (previously run; fails on existing unrelated lint errors in `Documents/MailModal.tsx` and `InstallPrompt/InstallPromptContainer.tsx`, plus existing warnings)

## Screenshots
- Not applicable; runtime fill-map/form-data/profile-sync behavior only.

## Notes
- Companion PRs: [keepid_server_next #95](https://github.com/keepid/keepid_server_next/pull/95), [keepid_dev_portal #16](https://github.com/keepid/keepid_dev_portal/pull/16).
