### PR TITLE
[codex] Improve client name search

### DIFF
--- a/src/components/Applications/ApplicationForm.tsx
+++ b/src/components/Applications/ApplicationForm.tsx
@@ -8,6 +8,7 @@ import { useHistory } from 'react-router-dom';
 
 import getServerURL from '../../serverOverride';
 import Role from '../../static/Role';
+import { getClientSearchCandidateQueries, matchesClientSearchQuery } from '../../utils/clientSearch';
 import PromptOnLeave from '../BaseComponents/PromptOnLeave';
 import InteractiveFormWizard from '../InteractiveForms/InteractiveFormWizard';
 import SignAndDownloadViewer from '../InteractiveForms/SignAndDownloadViewer';
@@ -110,29 +111,8 @@ interface ClientSearchResult {
 
 const MAX_CLIENT_RESULTS = 25;
 
-function normalizeSearchText(value: string): string {
-  return value.trim().toLowerCase();
-}
-
-function matchesClientSearchQuery(client: ClientSearchResult, query: string): boolean {
-  const normalizedQuery = normalizeSearchText(query);
-  if (!normalizedQuery) return false;
-  const tokens = normalizedQuery.split(/\s+/).filter(Boolean);
-  if (tokens.length === 0) return false;
-
-  const first = normalizeSearchText(client.firstName || '');
-  const last = normalizeSearchText(client.lastName || '');
-  const full = normalizeSearchText(`${client.firstName || ''} ${client.lastName || ''}`);
-  const username = normalizeSearchText(client.username || '');
-  const email = normalizeSearchText(client.email || '');
-
-  return tokens.every((token) => (
-    first.includes(token)
-    || last.includes(token)
-    || full.includes(token)
-    || username.includes(token)
-    || email.includes(token)
-  ));
+function getClientSearchDisplayName(client: ClientSearchResult): string {
+  return `${client.firstName || ''} ${client.lastName || ''}`.trim() || client.email || 'Client';
 }
 
 export default function ApplicationForm({
@@ -288,28 +268,38 @@ export default function ApplicationForm({
     setSearchingClients(true);
     setSearchError(null);
 
-    fetch(`${getServerURL()}/get-organization-members`, {
+    const searchQueries = getClientSearchCandidateQueries(debouncedClientQuery);
+
+    Promise.all(searchQueries.map((name) => fetch(`${getServerURL()}/get-organization-members`, {
       method: 'POST',
       credentials: 'include',
       signal: controller.signal,
       body: JSON.stringify({
         role: userRole,
         listType: 'clients',
-        name: debouncedClientQuery,
+        name,
       }),
-    })
-      .then((response) => response.json())
-      .then((responseJSON) => {
+    }).then((response) => response.json())))
+      .then((responses) => {
         if (clientSearchRequestIdRef.current !== requestId) return;
-        if (responseJSON.status === 'SUCCESS' && Array.isArray(responseJSON.people)) {
-          const filtered = responseJSON.people
-            .filter((client: ClientSearchResult) => matchesClientSearchQuery(client, debouncedClientQuery))
-            .slice(0, MAX_CLIENT_RESULTS);
-          setSearchResults(filtered);
-          return;
-        }
-        setSearchResults([]);
-        if (responseJSON.status && responseJSON.status !== 'USER_NOT_FOUND') {
+        const peopleByUsername = new Map<string, ClientSearchResult>();
+        let hasSearchError = false;
+
+        responses.forEach((responseJSON) => {
+          if (responseJSON.status === 'SUCCESS' && Array.isArray(responseJSON.people)) {
+            responseJSON.people.forEach((client: ClientSearchResult) => {
+              if (client.username) peopleByUsername.set(client.username, client);
+            });
+          } else if (responseJSON.status && responseJSON.status !== 'USER_NOT_FOUND') {
+            hasSearchError = true;
+          }
+        });
+
+        const filtered = Array.from(peopleByUsername.values())
+          .filter((client: ClientSearchResult) => matchesClientSearchQuery(client, debouncedClientQuery))
+          .slice(0, MAX_CLIENT_RESULTS);
+        setSearchResults(filtered);
+        if (hasSearchError && filtered.length === 0) {
           setSearchError('Could not load client search results.');
         }
       })
@@ -403,7 +393,7 @@ export default function ApplicationForm({
   }, []);
 
   const selectExistingClient = useCallback((client: ClientSearchResult) => {
-    const resolvedName = `${client.firstName || ''} ${client.lastName || ''}`.trim() || client.username;
+    const resolvedName = getClientSearchDisplayName(client);
     setTargetClientUsername(client.username);
     setTargetClientName(resolvedName);
     setClientQuery(resolvedName);
@@ -735,7 +725,8 @@ export default function ApplicationForm({
                     {showClientResults && searchResults.length > 0 && (
                       <div className="tw-border-2 tw-rounded-lg tw-mt-3 tw-divide-y tw-divide-gray-200 tw-max-h-80 tw-overflow-y-auto">
                         {searchResults.map((client) => {
-                          const displayName = `${client.firstName || ''} ${client.lastName || ''}`.trim() || client.username;
+                          const displayName = getClientSearchDisplayName(client);
+                          const secondaryLabel = client.email?.trim();
                           return (
                             <button
                               key={client.username}
@@ -744,7 +735,9 @@ export default function ApplicationForm({
                               className="tw-w-full tw-text-left tw-px-5 tw-py-4 hover:tw-bg-gray-50 tw-border-0 tw-bg-white"
                             >
                               <div className="tw-font-semibold tw-text-lg">{displayName}</div>
-                              <div className="tw-text-sm tw-text-gray-500">{client.username}</div>
+                              {secondaryLabel && (
+                                <div className="tw-text-sm tw-text-gray-500">{secondaryLabel}</div>
+                              )}
                             </button>
                           );
                         })}

--- a/src/components/Applications/ViewApplications.tsx
+++ b/src/components/Applications/ViewApplications.tsx
@@ -9,6 +9,7 @@ import { Link, Redirect, Route, Switch } from 'react-router-dom';
 import getServerURL from '../../serverOverride';
 import FileType from '../../static/FileType';
 import Role from '../../static/Role';
+import { getClientSearchCandidateQueries, matchesClientSearchQuery } from '../../utils/clientSearch';
 import DataTable, { DataTableColumn } from '../BaseComponents/DataTable';
 import RowActionMenu, { RowAction } from '../BaseComponents/RowActionMenu';
 import {
@@ -214,7 +215,7 @@ class ViewApplications extends Component<Props & RouteComponentProps, State, {}>
     }));
 
   getClientSearchDisplayName = (client: ClientSearchResult): string =>
-    `${client.firstName || ''} ${client.lastName || ''}`.trim() || client.username;
+    `${client.firstName || ''} ${client.lastName || ''}`.trim() || client.email || 'Client';
 
   resetModalClientPicker = () => {
     const { clientUsername, clientName } = this.state;
@@ -246,31 +247,41 @@ class ViewApplications extends Component<Props & RouteComponentProps, State, {}>
       return;
     }
 
+    const searchQueries = getClientSearchCandidateQueries(trimmedQuery);
+
     this.setState({ modalClientSearching: true });
-    fetch(`${getServerURL()}/get-organization-members`, {
+    Promise.all(searchQueries.map((name) => fetch(`${getServerURL()}/get-organization-members`, {
       method: 'POST',
       credentials: 'include',
       body: JSON.stringify({
         role: this.props.role,
         listType: 'clients',
-        name: trimmedQuery,
+        name,
       }),
-    })
-      .then((response) => response.json())
-      .then((responseJSON) => {
+    }).then((response) => response.json())))
+      .then((responses) => {
         const latestQuery = this.state.modalClientQuery.trim();
         if (latestQuery !== trimmedQuery) return;
-        if (responseJSON.status === 'SUCCESS' && Array.isArray(responseJSON.people)) {
-          this.setState({
-            modalClientResults: responseJSON.people.slice(0, 25),
-            modalClientSearching: false,
-          });
-          return;
-        }
+        const peopleByUsername = new Map<string, ClientSearchResult>();
+        let hasSearchError = false;
+
+        responses.forEach((responseJSON) => {
+          if (responseJSON.status === 'SUCCESS' && Array.isArray(responseJSON.people)) {
+            responseJSON.people.forEach((client: ClientSearchResult) => {
+              if (client.username) peopleByUsername.set(client.username, client);
+            });
+          } else if (responseJSON.status && responseJSON.status !== 'USER_NOT_FOUND') {
+            hasSearchError = true;
+          }
+        });
+
+        const filtered = Array.from(peopleByUsername.values())
+          .filter((client: ClientSearchResult) => matchesClientSearchQuery(client, trimmedQuery))
+          .slice(0, 25);
         this.setState({
-          modalClientResults: [],
+          modalClientResults: filtered,
           modalClientSearching: false,
-          modalClientError: responseJSON.status && responseJSON.status !== 'USER_NOT_FOUND'
+          modalClientError: hasSearchError && filtered.length === 0
             ? 'Could not load client search results.'
             : null,
         });
@@ -1041,6 +1052,7 @@ class ViewApplications extends Component<Props & RouteComponentProps, State, {}>
           <div className="tw-border tw-rounded tw-mt-2 tw-divide-y tw-divide-gray-200 tw-max-h-56 tw-overflow-y-auto">
             {modalClientResults.map((client) => {
               const displayName = this.getClientSearchDisplayName(client);
+              const secondaryLabel = client.email?.trim();
               return (
                 <button
                   key={client.username}
@@ -1050,7 +1062,9 @@ class ViewApplications extends Component<Props & RouteComponentProps, State, {}>
                   disabled={disabled}
                 >
                   <div className="tw-font-semibold">{displayName}</div>
-                  <div className="tw-text-sm tw-text-gray-500">{client.username}</div>
+                  {secondaryLabel && (
+                    <div className="tw-text-sm tw-text-gray-500">{secondaryLabel}</div>
+                  )}
                 </button>
               );
             })}

--- a/src/components/LandingPages/WorkerLanding.tsx
+++ b/src/components/LandingPages/WorkerLanding.tsx
@@ -8,6 +8,7 @@ import getServerURL from '../../serverOverride';
 import GenericProfilePicture from '../../static/images/generalprofilepic.png';
 import VisualizationSVG from '../../static/images/visualization.svg';
 import Role from '../../static/Role';
+import { getClientSearchCandidateQueries, matchesClientSearchQuery } from '../../utils/clientSearch';
 import { canUseApplications, canUseClientNotifications } from '../../utils/featureAccess';
 import { formatPhoneForDisplay } from '../../utils/phone';
 import IdPickupNotificationForm from '../Notifications/IdPickupNotificationForm';
@@ -50,34 +51,6 @@ function creationTimeMs(client: TargetClient): number | null {
   if (raw == null || raw === '') return null;
   const t = new Date(raw).getTime();
   return Number.isNaN(t) ? null : t;
-}
-
-function normalizeSearchText(value: string): string {
-  return value.trim().toLowerCase();
-}
-
-function matchesClientSearchQuery(client: TargetClient, query: string): boolean {
-  const normalizedQuery = normalizeSearchText(query);
-  if (!normalizedQuery) return true;
-
-  const tokens = normalizedQuery.split(/\s+/).filter(Boolean);
-  if (tokens.length === 0) return true;
-
-  const first = normalizeSearchText(client.firstName || '');
-  const last = normalizeSearchText(client.lastName || '');
-  const full = normalizeSearchText(`${client.firstName || ''} ${client.lastName || ''}`);
-  const username = normalizeSearchText(client.username || '');
-  const phone = normalizeSearchText(client.phone || '');
-  const email = normalizeSearchText(client.email || '');
-
-  return tokens.every((token) => (
-    first.includes(token)
-    || last.includes(token)
-    || full.includes(token)
-    || username.includes(token)
-    || phone.includes(token)
-    || email.includes(token)
-  ));
 }
 
 function formatBirthDateForDisplay(value: string): string {
@@ -187,32 +160,39 @@ const WorkerLanding: React.FC<Props> = ({ username, name, organization, role, lo
       setCurrentPage(1);
 
       try {
-        const res = await fetch(`${getServerURL()}/get-organization-members`, {
-          signal,
-          method: 'POST',
-          credentials: 'include',
-          body: JSON.stringify({
-            role,
-            listType: 'clients',
-            name: submittedSearchName,
-          }),
-        });
+        const searchQueries = getClientSearchCandidateQueries(submittedSearchName, true);
+        const responses = await Promise.all(searchQueries.map(async (name) => {
+          const res = await fetch(`${getServerURL()}/get-organization-members`, {
+            signal,
+            method: 'POST',
+            credentials: 'include',
+            body: JSON.stringify({
+              role,
+              listType: 'clients',
+              name,
+            }),
+          });
+          return res.json();
+        }));
 
-        const responseJSON = await res.json();
-        const { people, status } = responseJSON;
-
-        if (status === 'AUTH_FAILURE') {
+        if (responses.some((responseJSON) => responseJSON.status === 'AUTH_FAILURE')) {
           alert.show('Please sign in again to continue.');
           logOut();
           return;
         }
 
-        let filteredPeople: TargetClient[] = [];
-        if (status !== 'USER_NOT_FOUND' && Array.isArray(people)) {
-          filteredPeople = people
-            .map((person: TargetClient) => ({ ...person, photo: null }))
-            .filter((person: TargetClient) => matchesClientSearchQuery(person, submittedSearchName));
-        }
+        const peopleByUsername = new Map<string, TargetClient>();
+        responses.forEach((responseJSON) => {
+          if (responseJSON.status !== 'USER_NOT_FOUND' && Array.isArray(responseJSON.people)) {
+            responseJSON.people.forEach((person: TargetClient) => {
+              if (person.username) peopleByUsername.set(person.username, person);
+            });
+          }
+        });
+
+        const filteredPeople = Array.from(peopleByUsername.values())
+          .map((person: TargetClient) => ({ ...person, photo: null }))
+          .filter((person: TargetClient) => matchesClientSearchQuery(person, submittedSearchName));
 
         if (filteredPeople.length > 0) {
           setClients(filteredPeople);

--- a/src/utils/clientSearch.test.ts
+++ b/src/utils/clientSearch.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { getClientSearchCandidateQueries, matchesClientSearchQuery } from './clientSearch';
+
+describe('clientSearch', () => {
+  it('matches clients when the query contains a first and last name', () => {
+    expect(matchesClientSearchQuery({
+      username: 'internal-123',
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      email: 'ada@example.org',
+    }, 'Ada Lovelace')).toBe(true);
+  });
+
+  it('matches names even when the entered name order is reversed', () => {
+    expect(matchesClientSearchQuery({
+      username: 'internal-123',
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+    }, 'lovelace ada')).toBe(true);
+  });
+
+  it('builds candidate server queries from the full query and name tokens', () => {
+    expect(getClientSearchCandidateQueries('  Ada   Lovelace  ')).toEqual([
+      'Ada Lovelace',
+      'Ada',
+      'Lovelace',
+    ]);
+  });
+
+  it('can include an empty search for landing pages that load all clients', () => {
+    expect(getClientSearchCandidateQueries('   ', true)).toEqual(['']);
+  });
+});

--- a/src/utils/clientSearch.ts
+++ b/src/utils/clientSearch.ts
@@ -1,0 +1,52 @@
+export interface ClientSearchable {
+  username?: string;
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+  email?: string;
+}
+
+export function normalizeClientSearchText(value: string | undefined | null): string {
+  return (value || '').trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+export function getClientSearchCandidateQueries(query: string, includeEmpty = false): string[] {
+  const trimmedQuery = query.trim().replace(/\s+/g, ' ');
+  if (!trimmedQuery) return includeEmpty ? [''] : [];
+
+  const candidates = [
+    trimmedQuery,
+    ...trimmedQuery.split(' ').filter((token) => token.length >= 2),
+  ];
+  const seen = new Set<string>();
+  return candidates.filter((candidate) => {
+    const key = candidate.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function matchesClientSearchQuery(client: ClientSearchable, query: string): boolean {
+  const normalizedQuery = normalizeClientSearchText(query);
+  if (!normalizedQuery) return true;
+
+  const tokens = normalizedQuery.split(' ').filter(Boolean);
+  if (tokens.length === 0) return true;
+
+  const first = normalizeClientSearchText(client.firstName);
+  const last = normalizeClientSearchText(client.lastName);
+  const full = normalizeClientSearchText(`${client.firstName || ''} ${client.lastName || ''}`);
+  const username = normalizeClientSearchText(client.username);
+  const phone = normalizeClientSearchText(client.phone);
+  const email = normalizeClientSearchText(client.email);
+
+  return tokens.every((token) => (
+    first.includes(token)
+    || last.includes(token)
+    || full.includes(token)
+    || username.includes(token)
+    || phone.includes(token)
+    || email.includes(token)
+  ));
+}


### PR DESCRIPTION
## Summary
- Make client search resilient to full-name queries with spaces by querying the full input plus name tokens and locally filtering the merged results.
- Reuse the shared search matching in the worker landing and application client pickers.
- Stop showing internal usernames in application client search result rows; show the client name and optional email instead.

## Verification
- `npx vitest run src/utils/clientSearch.test.ts`
- `npx eslint src/utils/clientSearch.ts src/utils/clientSearch.test.ts src/components/LandingPages/WorkerLanding.tsx src/components/Applications/ApplicationForm.tsx src/components/Applications/ViewApplications.tsx --ext .ts,.tsx --quiet`
- `npm run build`
- `npm run lint:ts -- --quiet` *(fails on existing unrelated lint errors in `src/components/Documents/MailModal.tsx` and `src/components/InstallPrompt/InstallPromptContainer.tsx`)*

## Screenshots
- Not captured; this is a search matching/privacy display fix without new layout states.

## Notes
- Full repo TypeScript lint is still blocked by pre-existing unrelated errors in the files noted above.
