### PR TITLE
Add full feature identity override

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -209,8 +209,8 @@ class App extends React.Component<{}, State, {}> {
 
   render() {
     const { role, username, name, organization } = this.state;
-    const canAccessApplications = canUseApplications(role, organization);
-    const canAccessCommunications = canUseCommunications(role, organization);
+    const canAccessApplications = canUseApplications(role, organization, username);
+    const canAccessCommunications = canUseCommunications(role, organization, username);
     const renderHome = () => (
       <Home
         logIn={this.logIn}
@@ -236,6 +236,7 @@ class App extends React.Component<{}, State, {}> {
               logOut={this.logOut}
               role={role}
               organization={organization}
+              username={username}
             />
             {/* PWA install nudge — opens once per login session.
                 Triggered by username change; lib/pwa handles platform + dismissal logic. */}
@@ -611,6 +612,7 @@ class App extends React.Component<{}, State, {}> {
                       <ProfilePage
                         viewerRole={role}
                         viewerOrganization={organization}
+                        viewerUsername={username}
                       />
                     );
                   }
@@ -645,6 +647,7 @@ class App extends React.Component<{}, State, {}> {
                         targetUsername={clientUsername}
                         viewerRole={role}
                         viewerOrganization={organization}
+                        viewerUsername={username}
                       />
                     );
                   }

--- a/src/components/Documents/DocumentsInlineUpload.tsx
+++ b/src/components/Documents/DocumentsInlineUpload.tsx
@@ -135,7 +135,7 @@ export default function DocumentsInlineUpload({
   // Notify flow
   const canNotify = !!viewerUsername
     && viewerUsername !== targetUser
-    && canUseClientNotifications(viewerRole, organizationName);
+    && canUseClientNotifications(viewerRole, organizationName, viewerUsername);
   const [showNotifyConfirm, setShowNotifyConfirm] = useState(false);
   const [clientDisplayName, setClientDisplayName] = useState<string>(clientNameProp || '');
   const [clientPhone, setClientPhone] = useState<string>('');

--- a/src/components/Documents/MyDocuments.tsx
+++ b/src/components/Documents/MyDocuments.tsx
@@ -502,7 +502,11 @@ class MyDocuments extends Component<Props, State> {
     if (
       this.props.userRole === Role.Client
       && this.isStaffViewer()
-      && canUseClientNotifications(this.props.viewerRole, this.props.organizationName)
+      && canUseClientNotifications(
+        this.props.viewerRole,
+        this.props.organizationName,
+        this.props.viewerUsername,
+      )
     ) {
       actions.push({
         label: 'Notify',
@@ -639,6 +643,7 @@ class MyDocuments extends Component<Props, State> {
     const canAccessApplications = canUseApplications(
       this.props.viewerRole || this.props.userRole,
       this.props.organizationName,
+      this.props.viewerUsername || this.props.username,
     );
 
     return (
@@ -648,6 +653,7 @@ class MyDocuments extends Component<Props, State> {
             <ViewDocument
               userRole={currentUserRole}
               viewerRole={this.props.viewerRole}
+              viewerUsername={this.props.viewerUsername}
               organizationName={this.props.organizationName}
               documentId={currentDocumentId}
               documentName={currentDocumentName}

--- a/src/components/Documents/ViewDocument.tsx
+++ b/src/components/Documents/ViewDocument.tsx
@@ -25,6 +25,7 @@ interface Props {
   customIdCategory?: string;
   clientName?: string;
   viewerRole?: Role;
+  viewerUsername?: string;
   organizationName?: string;
   onDownloadCurrentDocument: () => void;
   onRequestDeleteCurrentDocument: () => void;
@@ -46,6 +47,7 @@ const ViewDocument: React.FC<Props> = ({
   customIdCategory,
   clientName,
   viewerRole,
+  viewerUsername,
   organizationName,
   onDownloadCurrentDocument,
   onRequestDeleteCurrentDocument,
@@ -101,7 +103,7 @@ const ViewDocument: React.FC<Props> = ({
   const isStaffViewer = viewerRole === Role.Worker
     || viewerRole === Role.Admin
     || viewerRole === Role.Director;
-  const canNotify = isStaffViewer && canUseClientNotifications(viewerRole, organizationName);
+  const canNotify = isStaffViewer && canUseClientNotifications(viewerRole, organizationName, viewerUsername);
 
   const uploadedAtLabel = (() => {
     if (!documentDate) return '';

--- a/src/components/Header.fixture.tsx
+++ b/src/components/Header.fixture.tsx
@@ -33,6 +33,7 @@ function HeaderFixture({ isLoggedIn, role }: Props) {
       isLoggedIn={isLoggedIn}
       role={role}
       organization="Team Keep"
+      username="demo@keep.id"
       alert={alert}
     />
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,17 +20,18 @@ interface Props {
   isLoggedIn: boolean;
   role: Role;
   organization: string;
+  username: string;
   alert: any;
 }
 
 interface State {}
 
 // We extend React.Component with Props & State
-function Header({ logIn, logOut, isLoggedIn, role, organization, alert }: Props) {
+function Header({ logIn, logOut, isLoggedIn, role, organization, username, alert }: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const isStaffUser = role === Role.Admin || role === Role.Director || role === Role.Worker;
-  const showApplicationsLink = isStaffUser && canUseApplications(role, organization);
-  const showCommunicationsLink = canUseCommunications(role, organization);
+  const showApplicationsLink = isStaffUser && canUseApplications(role, organization, username);
+  const showCommunicationsLink = canUseCommunications(role, organization, username);
 
   // Updated NavLink
   const NavLink = ({ to, children }: { to: string; children: React.ReactNode }) => (

--- a/src/components/LandingPages/ClientDashboardSummaryCards.tsx
+++ b/src/components/LandingPages/ClientDashboardSummaryCards.tsx
@@ -123,13 +123,15 @@ type CountLoadState =
 interface Props {
   role: Role;
   organization: string;
+  username: string;
 }
 
 export default function ClientDashboardSummaryCards({
   role,
   organization,
+  username,
 }: Props): React.ReactElement {
-  const canAccessApplications = canUseApplications(role, organization);
+  const canAccessApplications = canUseApplications(role, organization, username);
   const [documents, setDocuments] = useState<CountLoadState>({ status: 'loading' });
   const [applications, setApplications] = useState<CountLoadState>({
     status: 'loading',

--- a/src/components/LandingPages/ClientLanding.tsx
+++ b/src/components/LandingPages/ClientLanding.tsx
@@ -10,12 +10,12 @@ import ClientDashboardSummaryCards from './ClientDashboardSummaryCards';
 
 interface Props extends RouteComponentProps {
   name: String;
-  username: String;
+  username: string;
   role: Role;
   organization: string;
 }
 
-function ClientLanding({ role, organization }: Props): React.ReactElement {
+function ClientLanding({ role, organization, username }: Props): React.ReactElement {
   return (
     <div id="Buttons" className="container pt-5">
       <Helmet>
@@ -25,7 +25,7 @@ function ClientLanding({ role, organization }: Props): React.ReactElement {
       <div className="mb-3">
         <QuickAccessCards />
       </div>
-      <ClientDashboardSummaryCards role={role} organization={organization} />
+      <ClientDashboardSummaryCards role={role} organization={organization} username={username} />
     </div>
   );
 }

--- a/src/components/LandingPages/WorkerLanding.tsx
+++ b/src/components/LandingPages/WorkerLanding.tsx
@@ -137,9 +137,9 @@ const WorkerLanding: React.FC<Props> = ({ username, name, organization, role, lo
   const [viewMode, setViewMode] = useState<ClientViewMode>('list');
   const [isLoading, setIsLoading] = useState(true);
   const { path } = useRouteMatch();
-  const canAccessApplications = canUseApplications(role, organization);
-  const canAccessCommunications = canUseCommunications(role, organization);
-  const canAccessNotifications = canUseClientNotifications(role, organization);
+  const canAccessApplications = canUseApplications(role, organization, username);
+  const canAccessCommunications = canUseCommunications(role, organization, username);
+  const canAccessNotifications = canUseClientNotifications(role, organization, username);
 
   const loadProfilePhoto = useCallback(async (clientsArray: TargetClient[], signal: AbortSignal) => {
     const clientsWithPhoto = clientsArray.filter((client) => client.profilePhoto != null);

--- a/src/components/Profile/ProfilePage.tsx
+++ b/src/components/Profile/ProfilePage.tsx
@@ -23,6 +23,7 @@ type Props = {
   targetUsername?: string;
   viewerRole?: Role;
   viewerOrganization?: string;
+  viewerUsername?: string;
 };
 
 export type NameObj = {
@@ -74,6 +75,7 @@ export default function ProfilePage({
   targetUsername,
   viewerRole,
   viewerOrganization,
+  viewerUsername,
 }: Props) {
   const alert = useAlert();
   const history = useHistory();
@@ -93,17 +95,19 @@ export default function ProfilePage({
         return {
           role: parsed.role as Role,
           organization: parsed.organization as string,
+          username: parsed.username as string,
         };
       }
     } catch { /* ignore */ }
-    return { role: '', organization: '' };
+    return { role: '', organization: '', username: '' };
   }, []);
   const currentUserRole = viewerRole || currentUserSession.role;
   const currentUserOrganization = viewerOrganization || currentUserSession.organization;
+  const currentUsername = viewerUsername || currentUserSession.username;
 
   const isAdmin = currentUserRole === Role.Admin || currentUserRole === Role.Director;
-  const canAccessApplications = canUseApplications(currentUserRole, currentUserOrganization);
-  const canAccessCommunicationHistory = canUseCommunications(currentUserRole, currentUserOrganization);
+  const canAccessApplications = canUseApplications(currentUserRole, currentUserOrganization, currentUsername);
+  const canAccessCommunicationHistory = canUseCommunications(currentUserRole, currentUserOrganization, currentUsername);
 
   const canEditClientIdentityFields = useMemo(
     () =>

--- a/src/utils/featureAccess.test.ts
+++ b/src/utils/featureAccess.test.ts
@@ -5,6 +5,7 @@ import {
   canUseApplications,
   canUseClientNotifications,
   canUseCommunications,
+  hasFullFeatureIdentityOverride,
   isTeamKeepOrganization,
 } from './featureAccess';
 
@@ -15,11 +16,23 @@ describe('feature access policy', () => {
     expect(isTeamKeepOrganization('Demo Org')).toBe(false);
   });
 
+  it('recognizes approved full-feature identity prefixes', () => {
+    expect(hasFullFeatureIdentityOverride('danieljoo@keep.id')).toBe(true);
+    expect(hasFullFeatureIdentityOverride(' ConnorChong+dev@keep.id ')).toBe(true);
+    expect(hasFullFeatureIdentityOverride('steffencornwell')).toBe(true);
+    expect(hasFullFeatureIdentityOverride('team.danieljoo@keep.id')).toBe(false);
+  });
+
   it('allows applications only for signed-in Team Keep users', () => {
     expect(canUseApplications(Role.Client, 'Team Keep')).toBe(true);
     expect(canUseApplications(Role.Worker, 'Team Keep')).toBe(true);
     expect(canUseApplications(Role.Admin, 'Demo Org')).toBe(false);
     expect(canUseApplications(Role.LoggedOut, 'Team Keep')).toBe(false);
+  });
+
+  it('allows applications for approved full-feature identities outside Team Keep', () => {
+    expect(canUseApplications(Role.Admin, 'Demo Org', 'danieljoo@keep.id')).toBe(true);
+    expect(canUseApplications(Role.LoggedOut, 'Demo Org', 'danieljoo@keep.id')).toBe(false);
   });
 
   it('allows communications only for Team Keep staff', () => {
@@ -30,8 +43,18 @@ describe('feature access policy', () => {
     expect(canUseCommunications(Role.Admin, 'Demo Org')).toBe(false);
   });
 
+  it('allows communications for approved full-feature staff identities outside Team Keep', () => {
+    expect(canUseCommunications(Role.Worker, 'Demo Org', 'connorchong@keep.id')).toBe(true);
+    expect(canUseCommunications(Role.Client, 'Demo Org', 'connorchong@keep.id')).toBe(false);
+  });
+
   it('keeps client notifications admin-only for Team Keep', () => {
     expect(canUseClientNotifications(Role.Admin, 'Team Keep')).toBe(true);
     expect(canUseClientNotifications(Role.Worker, 'Team Keep')).toBe(false);
+  });
+
+  it('allows client notifications for approved full-feature admin identities outside Team Keep', () => {
+    expect(canUseClientNotifications(Role.Admin, 'Demo Org', 'steffencornwell@keep.id')).toBe(true);
+    expect(canUseClientNotifications(Role.Worker, 'Demo Org', 'steffencornwell@keep.id')).toBe(false);
   });
 });

--- a/src/utils/featureAccess.ts
+++ b/src/utils/featureAccess.ts
@@ -1,6 +1,7 @@
 import Role from '../static/Role';
 
 const FULL_FEATURE_ORG_NAMES = ['Team Keep'];
+const FULL_FEATURE_IDENTITY_PREFIXES = ['steffencornwell', 'danieljoo', 'connorchong'];
 
 type RoleLike = Role | string | null | undefined;
 
@@ -8,9 +9,25 @@ function normalizedOrganizationName(organization?: string | null): string {
   return (organization || '').trim().toLowerCase();
 }
 
+function normalizedIdentity(identity?: string | null): string {
+  return (identity || '').trim().toLowerCase();
+}
+
 export function isTeamKeepOrganization(organization?: string | null): boolean {
   const normalized = normalizedOrganizationName(organization);
   return FULL_FEATURE_ORG_NAMES.some((name) => normalizedOrganizationName(name) === normalized);
+}
+
+export function hasFullFeatureIdentityOverride(identity?: string | null): boolean {
+  const normalized = normalizedIdentity(identity);
+  return FULL_FEATURE_IDENTITY_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
+function canUseFullFeatureOrganization(
+  organization?: string | null,
+  identity?: string | null,
+): boolean {
+  return isTeamKeepOrganization(organization) || hasFullFeatureIdentityOverride(identity);
 }
 
 export function isAdminRole(role: RoleLike): boolean {
@@ -25,14 +42,26 @@ function isSignedInRole(role: RoleLike): boolean {
   return !!role && role !== Role.LoggedOut;
 }
 
-export function canUseApplications(role: RoleLike, organization?: string | null): boolean {
-  return isSignedInRole(role) && isTeamKeepOrganization(organization);
+export function canUseApplications(
+  role: RoleLike,
+  organization?: string | null,
+  identity?: string | null,
+): boolean {
+  return isSignedInRole(role) && canUseFullFeatureOrganization(organization, identity);
 }
 
-export function canUseCommunications(role: RoleLike, organization?: string | null): boolean {
-  return isStaffRole(role) && isTeamKeepOrganization(organization);
+export function canUseCommunications(
+  role: RoleLike,
+  organization?: string | null,
+  identity?: string | null,
+): boolean {
+  return isStaffRole(role) && canUseFullFeatureOrganization(organization, identity);
 }
 
-export function canUseClientNotifications(role: RoleLike, organization?: string | null): boolean {
-  return isAdminRole(role) && isTeamKeepOrganization(organization);
+export function canUseClientNotifications(
+  role: RoleLike,
+  organization?: string | null,
+  identity?: string | null,
+): boolean {
+  return isAdminRole(role) && canUseFullFeatureOrganization(organization, identity);
 }


### PR DESCRIPTION
## Summary
- Centralize the full-feature access escape hatch in `featureAccess`.
- Allow signed-in users whose username/email starts with `steffencornwell`, `danieljoo`, or `connorchong` to bypass the Team Keep org restriction for applications and communications.
- Thread the signed-in username through route guards, nav links, landing cards, profile sections, and document notification/application affordances so visibility matches route access.

## Verification
- `npx vitest run src/utils/featureAccess.test.ts`
- `npm run lint:ts` (passes with existing warnings)
- `npm run build`

## Screenshots
- Not applicable; access-policy change only.

## Notes
- Preserves existing role checks: communications still require staff, notifications still require admin/director, and logged-out users remain denied.
