### PR TITLE
Load application selector flow from server

### DIFF
--- a/src/components/Applications/applicationSelector/flowApi.test.ts
+++ b/src/components/Applications/applicationSelector/flowApi.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  applicationSelectorFlowDefinition,
+  loadApplicationSelectorFlow,
+} from './flowApi';
+import type { ApplicationSelectorFlowDefinition } from './types';
+
+vi.mock('../../../serverOverride', () => ({
+  default: () => 'http://server.test',
+}));
+
+const remoteFlow: ApplicationSelectorFlowDefinition = {
+  id: 'remote-selector',
+  title: 'Remote Selector',
+  description: '',
+  questions: [],
+  outcomes: [],
+};
+
+describe('loadApplicationSelectorFlow', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('loads the uploaded selector flow from the server', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => remoteFlow,
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(loadApplicationSelectorFlow()).resolves.toEqual(remoteFlow);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://server.test/application-selector-flow',
+      {
+        method: 'GET',
+        credentials: 'include',
+        headers: { Accept: 'application/json' },
+      },
+    );
+  });
+
+  it('falls back to the bundled selector flow when the server flow is missing', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 404,
+    })));
+
+    await expect(loadApplicationSelectorFlow()).resolves.toBe(applicationSelectorFlowDefinition);
+  });
+
+  it('falls back to the bundled selector flow when the server response is malformed', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ status: 'SUCCESS' }),
+    })));
+
+    await expect(loadApplicationSelectorFlow()).resolves.toBe(applicationSelectorFlowDefinition);
+  });
+});

--- a/src/components/Applications/applicationSelector/flowApi.ts
+++ b/src/components/Applications/applicationSelector/flowApi.ts
@@ -7,7 +7,35 @@ import type { ApplicationSelectorAnswers, ApplicationSelectorFlowDefinition } fr
 export const applicationSelectorFlowDefinition =
   applicationSelectorFlowData as ApplicationSelectorFlowDefinition;
 
-export const loadApplicationSelectorFlow = async (): Promise<ApplicationSelectorFlowDefinition> => applicationSelectorFlowDefinition;
+const isApplicationSelectorFlowDefinition = (
+  value: unknown,
+): value is ApplicationSelectorFlowDefinition => {
+  if (!value || typeof value !== 'object') return false;
+  const flow = value as Partial<ApplicationSelectorFlowDefinition>;
+  return typeof flow.id === 'string'
+    && typeof flow.title === 'string'
+    && Array.isArray(flow.questions)
+    && Array.isArray(flow.outcomes);
+};
+
+export const loadApplicationSelectorFlow = async (): Promise<ApplicationSelectorFlowDefinition> => {
+  try {
+    const response = await fetch(`${getServerURL()}/application-selector-flow`, {
+      method: 'GET',
+      credentials: 'include',
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) return applicationSelectorFlowDefinition;
+
+    const remoteFlow = await response.json();
+    if (!isApplicationSelectorFlowDefinition(remoteFlow)) {
+      return applicationSelectorFlowDefinition;
+    }
+    return remoteFlow;
+  } catch {
+    return applicationSelectorFlowDefinition;
+  }
+};
 
 export const loadApplicationSelectorProfileAnswers = async (
   flow: ApplicationSelectorFlowDefinition,


### PR DESCRIPTION
## Summary
- Update the application selector loader to fetch `/application-selector-flow` from the server before using the bundled JSON fallback.
- Validate the returned shape enough to avoid replacing the picker with malformed JSON.
- Add focused tests for server success, missing server flow, and malformed server flow fallback behavior.

## Verification
- `npx vitest run src/components/Applications/applicationSelector/flowApi.test.ts src/components/Applications/applicationSelector/outcomeResolver.test.ts`
- `npx eslint src/components/Applications/applicationSelector/flowApi.ts src/components/Applications/applicationSelector/flowApi.test.ts`
- `npm run build`

## Screenshots
- Not applicable.

## Notes
- Depends on the server endpoint in https://github.com/keepid/keepid_server_next/pull/105.
