### PR TITLE
Send org return addresses as company-only

### DIFF
--- a/src/components/Documents/MailModal.tsx
+++ b/src/components/Documents/MailModal.tsx
@@ -284,7 +284,7 @@ export const MailModal: React.FC<Props> = ({
           fileId: documentId,
           mailDestination: destination,
           returnAddress: {
-            name: returnAddressData.name || returnAddressData.officeName,
+            name: returnAddressData.name,
             officeName: returnAddressData.officeName,
             street1: returnAddressData.street1,
             street2: returnAddressData.street2,
@@ -393,14 +393,14 @@ export const MailModal: React.FC<Props> = ({
         </div>
       )}
       <div>
-        <label className="tw-block tw-mb-1 tw-font-semibold">Office Name</label>
+        <label className="tw-block tw-mb-1 tw-font-semibold">Company / Department</label>
         <input
           type="text"
           name="officeName"
           value={data.officeName}
           onChange={(e) => handleAddressChange(e, target)}
           className={`tw-w-full tw-p-2 tw-border ${showInputError && data.officeName === '' && target === 'return' ? 'tw-border-red-500' : 'tw-border-gray-300'} tw-rounded`}
-          placeholder="Enter office name"
+          placeholder="Enter company or department"
           readOnly={!editable}
         />
       </div>


### PR DESCRIPTION
## Summary
- Stop copying the return-address company into `name` when no person name is present.
- Keep organization return addresses in `officeName` so Lob receives company-only return addresses instead of duplicate `name` + `company` lines.
- Rename the mail modal label from `Office Name` to `Company / Department`.

## Verification
- `npm run build`
- `npm run lint:ts` (passes with existing warnings)
- `npm run lint:scss`

## Screenshots
- Not captured; small copy/payload change in the existing mail modal.

## Notes
- `npm ci` was needed in the isolated worktree because dependencies were not installed there; `node_modules` remains untracked.
