### PR TITLE
Add outbound call recording controls

### DIFF
--- a/src/components/Communications/CallsPage.tsx
+++ b/src/components/Communications/CallsPage.tsx
@@ -1,6 +1,7 @@
 import './communications.css';
 
 import AddIcon from '@mui/icons-material/Add';
+import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
 import LocalPhoneOutlinedIcon from '@mui/icons-material/LocalPhoneOutlined';
 import RefreshOutlinedIcon from '@mui/icons-material/RefreshOutlined';
 import type { Call } from '@twilio/voice-sdk';
@@ -22,12 +23,14 @@ import {
   PromoteSharedResponse,
   scheduleCommunicationContactMessage,
   sendCommunicationContactMessage,
+  startTwilioVoiceRecording,
   updateCommunicationContactNote,
 } from './communicationsApi';
 import ContactEditorSheet from './ContactEditorSheet';
 import CreateContactModal from './CreateContactModal';
 
 type BrowserCallStatus = 'idle' | 'connecting' | 'ringing' | 'in-call' | 'ended' | 'error';
+type CallRecordingStatus = 'idle' | 'starting' | 'recording' | 'recording-only' | 'error';
 type CommunicationsLocationState = {
   clientUsername?: string;
   clientName?: string;
@@ -166,6 +169,10 @@ export default function CallsPage() {
   const [browserCallStatus, setBrowserCallStatus] = useState<BrowserCallStatus>('idle');
   const [browserCallError, setBrowserCallError] = useState('');
   const [isMuted, setIsMuted] = useState(false);
+  const [activeCallSid, setActiveCallSid] = useState('');
+  const [recordingConsentConfirmed, setRecordingConsentConfirmed] = useState(false);
+  const [callRecordingStatus, setCallRecordingStatus] = useState<CallRecordingStatus>('idle');
+  const [callRecordingMessage, setCallRecordingMessage] = useState('');
   const [callNoteDraft, setCallNoteDraft] = useState('');
   const [callNoteSaveError, setCallNoteSaveError] = useState('');
   const [isSavingCallNote, setIsSavingCallNote] = useState(false);
@@ -453,6 +460,10 @@ export default function CallsPage() {
     setBrowserCallStatus('idle');
     setBrowserCallError('');
     setIsMuted(false);
+    setActiveCallSid('');
+    setRecordingConsentConfirmed(false);
+    setCallRecordingStatus('idle');
+    setCallRecordingMessage('');
     setCallStartedAt(null);
     setElapsedSeconds(0);
   }
@@ -520,6 +531,10 @@ export default function CallsPage() {
     setBrowserCallStatus('connecting');
     setElapsedSeconds(0);
     setCallStartedAt(null);
+    setActiveCallSid('');
+    setRecordingConsentConfirmed(false);
+    setCallRecordingStatus('idle');
+    setCallRecordingMessage('');
     try {
       if (!Device.isSupported) {
         throw new Error('This browser does not support Twilio Voice calling.');
@@ -542,6 +557,7 @@ export default function CallsPage() {
       call.on('accept', () => {
         setBrowserCallStatus('in-call');
         setBrowserCallError('');
+        setActiveCallSid(call.parameters.CallSid || '');
         setCallStartedAt(Date.now());
         setElapsedSeconds(0);
       });
@@ -550,6 +566,7 @@ export default function CallsPage() {
         setBrowserCallStatus('ended');
         setCallStartedAt(null);
         setIsMuted(false);
+        setRecordingConsentConfirmed(false);
         refreshSelectedConversation();
       });
       call.on('cancel', () => {
@@ -557,12 +574,14 @@ export default function CallsPage() {
         setBrowserCallStatus('ended');
         setCallStartedAt(null);
         setIsMuted(false);
+        setRecordingConsentConfirmed(false);
       });
       call.on('reject', () => {
         activeCallRef.current = null;
         setBrowserCallStatus('ended');
         setCallStartedAt(null);
         setIsMuted(false);
+        setRecordingConsentConfirmed(false);
       });
       call.on('error', (error: Error) => {
         activeCallRef.current = null;
@@ -570,6 +589,7 @@ export default function CallsPage() {
         setBrowserCallStatus('error');
         setCallStartedAt(null);
         setIsMuted(false);
+        setRecordingConsentConfirmed(false);
       });
       call.on('reconnecting', () => {
         setBrowserCallStatus('connecting');
@@ -585,6 +605,37 @@ export default function CallsPage() {
       setBrowserCallStatus('error');
       setCallStartedAt(null);
       setIsMuted(false);
+      setRecordingConsentConfirmed(false);
+    }
+  }
+
+  async function startCallRecording() {
+    if (
+      browserCallStatus !== 'in-call'
+      || !activeCallSid
+      || !recordingConsentConfirmed
+      || callRecordingStatus === 'starting'
+      || callRecordingStatus === 'recording'
+      || callRecordingStatus === 'recording-only'
+    ) return;
+    setCallRecordingStatus('starting');
+    setCallRecordingMessage('');
+    try {
+      const response = await startTwilioVoiceRecording(activeCallSid, true);
+      if (response.status === 'SUCCESS' || response.status === 'ALREADY_RECORDING') {
+        setCallRecordingStatus('recording');
+        setCallRecordingMessage(response.message || 'Recording started. The transcript will appear after the call.');
+        return;
+      }
+      if (response.status === 'RECORDING_ONLY') {
+        setCallRecordingStatus('recording-only');
+        setCallRecordingMessage(response.message || 'Recording started, but transcription could not be started.');
+        return;
+      }
+      throw new Error(response.message || 'Could not start call recording.');
+    } catch (error) {
+      setCallRecordingStatus('error');
+      setCallRecordingMessage(error instanceof Error ? error.message : 'Could not start call recording.');
     }
   }
 
@@ -603,6 +654,7 @@ export default function CallsPage() {
     setBrowserCallStatus('ended');
     setCallStartedAt(null);
     setIsMuted(false);
+    setRecordingConsentConfirmed(false);
   }
 
   function updateContactInList(contact: CommunicationContact) {
@@ -989,6 +1041,52 @@ export default function CallsPage() {
                     {browserCallStatus === 'in-call' && <span>{formatDuration(elapsedSeconds)}</span>}
                     {browserCallError && <p>{browserCallError}</p>}
                   </div>
+                  <section className={`call-recording-panel ${callRecordingStatus}`}>
+                    {callRecordingStatus === 'recording' || callRecordingStatus === 'recording-only' ? (
+                      <div className="call-recording-active" role="status">
+                        <FiberManualRecordIcon fontSize="small" />
+                        <div>
+                          <strong>Recording</strong>
+                          <p>{callRecordingMessage}</p>
+                        </div>
+                      </div>
+                    ) : (
+                      <>
+                        <label className="call-recording-consent">
+                          <input
+                            type="checkbox"
+                            checked={recordingConsentConfirmed}
+                            disabled={browserCallStatus !== 'in-call' || callRecordingStatus === 'starting'}
+                            onChange={(event) => {
+                              setRecordingConsentConfirmed(event.target.checked);
+                              setCallRecordingMessage('');
+                              if (callRecordingStatus === 'error') setCallRecordingStatus('idle');
+                            }}
+                          />
+                          <span>
+                            I confirmed that everyone on the call verbally consented to recording and transcription.
+                          </span>
+                        </label>
+                        <button
+                          type="button"
+                          className="call-record-button"
+                          disabled={
+                            browserCallStatus !== 'in-call'
+                            || !activeCallSid
+                            || !recordingConsentConfirmed
+                            || callRecordingStatus === 'starting'
+                          }
+                          onClick={startCallRecording}
+                        >
+                          <FiberManualRecordIcon fontSize="small" />
+                          {callRecordingStatus === 'starting' ? 'Starting...' : 'Start recording'}
+                        </button>
+                        {callRecordingMessage && (
+                          <p className="call-recording-error" role="alert">{callRecordingMessage}</p>
+                        )}
+                      </>
+                    )}
+                  </section>
                   <div className="call-controls">
                     <button
                       type="button"

--- a/src/components/Communications/communications.css
+++ b/src/components/Communications/communications.css
@@ -642,6 +642,100 @@ body:has(.communications-shell),
   background: #fff5f5;
 }
 
+.call-recording-panel {
+  display: grid;
+  gap: 10px;
+  border: 1px solid #d9e2ec;
+  border-radius: 10px;
+  padding: 12px;
+  background: #f8fafc;
+}
+
+.call-recording-consent {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 9px;
+  align-items: flex-start;
+  color: #334e68;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.call-recording-consent input {
+  width: 16px;
+  height: 16px;
+  margin-top: 1px;
+}
+
+.call-record-button {
+  display: inline-flex;
+  align-items: center;
+  justify-self: start;
+  gap: 7px;
+  border: 1px solid #c73535;
+  border-radius: 999px;
+  padding: 9px 14px;
+  background: #fff;
+  color: #b42318;
+  font-weight: 800;
+}
+
+.call-record-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.call-recording-panel.recording,
+.call-recording-panel.recording-only {
+  border-color: #f0b8b8;
+  background: #fff5f5;
+}
+
+.call-recording-active {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 9px;
+  align-items: flex-start;
+  color: #b42318;
+}
+
+.call-recording-active svg {
+  margin-top: 1px;
+  animation: call-recording-pulse 1.5s ease-in-out infinite;
+}
+
+.call-recording-active strong {
+  display: block;
+  font-size: 14px;
+}
+
+.call-recording-active p,
+.call-recording-error {
+  margin: 2px 0 0;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.call-recording-active p {
+  color: #7a271a;
+}
+
+.call-recording-error {
+  color: #b42318;
+  font-weight: 700;
+}
+
+@keyframes call-recording-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.45;
+  }
+}
+
 .call-controls button,
 .call-controls a {
   border: 1px solid #bcccdc;

--- a/src/components/Communications/communicationsApi.ts
+++ b/src/components/Communications/communicationsApi.ts
@@ -159,6 +159,13 @@ export type TwilioVoiceTokenResponse = {
   expiresInSeconds: number;
 };
 
+export type StartVoiceRecordingResponse = {
+  status: string;
+  message?: string;
+  recordingSid?: string;
+  transcriptionSid?: string;
+};
+
 export class CommunicationApiError extends Error {
   statusCode: number;
 
@@ -428,6 +435,16 @@ export function scheduleMessage(username: string, body: string, sendAt: string, 
 
 export function getTwilioVoiceToken() {
   return jsonFetch<TwilioVoiceTokenResponse>('/api/communications/voice/token');
+}
+
+export function startTwilioVoiceRecording(callSid: string, consentConfirmed: boolean) {
+  return jsonFetch<StartVoiceRecordingResponse>(
+    `/api/communications/voice/calls/${encodeURIComponent(callSid)}/recording`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ consentConfirmed }),
+    },
+  );
 }
 
 export function getCallRecordingPlaybackUrl(callId: string) {


### PR DESCRIPTION
## Summary
- Add a consent acknowledgement and Record button to the active outbound-call modal.
- Keep recording disabled until the call is connected, the Twilio Call SID is available, and the worker confirms verbal consent.
- Show clear starting, recording, recording-only, and error states while preserving the existing post-call timeline refresh.

## Verification
- `npm run build`
- `npm run lint:ts` — 0 errors; existing warnings remain.
- `npm run lint:scss`
- `git diff --check`

## Screenshots
- Not included in this draft because the recording state requires a connected Twilio browser call. Capture desktop and mobile call-modal states during the deployment smoke test.

## Notes
- Companion server PR: https://github.com/keepid/keepid_server_next/pull/119
- Transcription begins with recording after consent and is displayed in call history after hang-up.
