### PR TITLE
Fix email-based feature access override

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,16 +55,19 @@ window.onload = () => {
 interface State {
   role: Role;
   username: string;
+  email: string;
   name: string;
   organization: string;
 }
 
 interface ContextInterface {
   username: string;
+  email: string;
   organization: string;
 }
 export const UserContext = React.createContext<ContextInterface>({
   username: '',
+  email: '',
   organization: '',
 });
 
@@ -79,6 +82,7 @@ class App extends React.Component<{}, State, {}> {
       this.state = {
         role: data.role,
         username: data.username,
+        email: data.email || '',
         name: data.name,
         organization: data.organization,
       };
@@ -86,6 +90,7 @@ class App extends React.Component<{}, State, {}> {
       this.state = {
         role: Role.LoggedOut,
         username: '',
+        email: '',
         name: '',
         organization: '',
       };
@@ -94,20 +99,30 @@ class App extends React.Component<{}, State, {}> {
     this.logOut = this.logOut.bind(this);
   }
 
-  logIn(role: Role, username: string, organization: string, name: string) {
-    this.setState({
+  logIn(role: Role, username: string, organization: string, name: string, email = '') {
+    this.setState((previousState) => ({
       role,
       username,
+      email: email || (previousState.username === username ? previousState.email : ''),
       name,
       organization,
+    }), () => {
+      const obj = {
+        role,
+        username,
+        email: this.state.email,
+        name,
+        organization,
+      };
+      sessionStorage.setItem('mySessionStorageData', JSON.stringify(obj));
+      this.hydrateCurrentUserEmail(username);
     });
-    const obj = { role, username, name, organization };
-    sessionStorage.setItem('mySessionStorageData', JSON.stringify(obj));
   }
 
   logOut() {
     this.setState({
       username: '',
+      email: '',
       name: '',
       organization: '',
       role: Role.LoggedOut,
@@ -119,6 +134,38 @@ class App extends React.Component<{}, State, {}> {
     });
     sessionStorage.clear();
   }
+
+  hydrateCurrentUserEmail = (expectedUsername: string) => {
+    fetch(`${getServerURL()}/get-user-info`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+      .then((response) => response.json())
+      .then((responseJSON) => {
+        const email = typeof responseJSON?.email === 'string' ? responseJSON.email.trim() : '';
+        if (
+          responseJSON?.status !== 'SUCCESS'
+          || responseJSON?.username !== expectedUsername
+          || this.state.username !== expectedUsername
+          || email === this.state.email
+        ) {
+          return;
+        }
+
+        this.setState({ email }, () => {
+          const jsonData = sessionStorage.getItem('mySessionStorageData');
+          if (!jsonData) return;
+          const data = JSON.parse(jsonData);
+          if (data.username !== expectedUsername) return;
+          sessionStorage.setItem('mySessionStorageData', JSON.stringify({ ...data, email }));
+        });
+      })
+      .catch(() => {
+        // Feature access can still fall back to the username when profile hydration fails.
+      });
+  };
 
   componentDidMount() {
     this.refreshAuthFromServer();
@@ -189,6 +236,8 @@ class App extends React.Component<{}, State, {}> {
               // the server's truth so the sidebar Profile Title reflects
               // the new name immediately.
               this.logIn(role(), username, organization, serverName);
+            } else {
+              this.hydrateCurrentUserEmail(username);
             }
           } else {
             // Server has a valid session but client has no local data.
@@ -208,9 +257,11 @@ class App extends React.Component<{}, State, {}> {
   };
 
   render() {
-    const { role, username, name, organization } = this.state;
-    const canAccessApplications = canUseApplications(role, organization, username);
-    const canAccessCommunications = canUseCommunications(role, organization, username);
+    const {
+      role, username, email, name, organization,
+    } = this.state;
+    const canAccessApplications = canUseApplications(role, organization, username, email);
+    const canAccessCommunications = canUseCommunications(role, organization, username, email);
     const renderHome = () => (
       <Home
         logIn={this.logIn}
@@ -220,7 +271,12 @@ class App extends React.Component<{}, State, {}> {
     );
     return (
       <Router>
-        <UserContext.Provider value={{ username: this.state.username, organization: this.state.organization }}>
+        <UserContext.Provider value={{
+          username: this.state.username,
+          email: this.state.email,
+          organization: this.state.organization,
+        }}
+        >
         <div className="App tw-flex tw-flex-col tw-min-h-screen">
           <div className="app tw-flex-1 tw-pb-12">
             <Helmet>
@@ -237,6 +293,7 @@ class App extends React.Component<{}, State, {}> {
               role={role}
               organization={organization}
               username={username}
+              email={email}
             />
             {/* PWA install nudge — opens once per login session.
                 Triggered by username change; lib/pwa handles platform + dismissal logic. */}
@@ -306,6 +363,7 @@ class App extends React.Component<{}, State, {}> {
                         name={name}
                         organization={organization}
                         username={username}
+                        email={email}
                         role={role}
                         logOut={this.logOut}
                       />
@@ -316,6 +374,7 @@ class App extends React.Component<{}, State, {}> {
                       <ClientLanding
                         name={name}
                         username={username}
+                        email={email}
                         role={role}
                         organization={organization}
                       />
@@ -388,6 +447,7 @@ class App extends React.Component<{}, State, {}> {
                         username={clientUsername}
                         viewerRole={role}
                         viewerUsername={username}
+                        viewerEmail={email}
                         viewerName={name}
                         organizationName={organization}
                       />
@@ -415,6 +475,7 @@ class App extends React.Component<{}, State, {}> {
                         viewerRole={role}
                         username={username}
                         viewerUsername={username}
+                        viewerEmail={email}
                         viewerName={name}
                         organizationName={organization}
                       />
@@ -613,6 +674,7 @@ class App extends React.Component<{}, State, {}> {
                         viewerRole={role}
                         viewerOrganization={organization}
                         viewerUsername={username}
+                        viewerEmail={email}
                       />
                     );
                   }
@@ -648,6 +710,7 @@ class App extends React.Component<{}, State, {}> {
                         viewerRole={role}
                         viewerOrganization={organization}
                         viewerUsername={username}
+                        viewerEmail={email}
                       />
                     );
                   }

--- a/src/components/Documents/DocumentsInlineUpload.tsx
+++ b/src/components/Documents/DocumentsInlineUpload.tsx
@@ -51,6 +51,7 @@ export interface DocumentsInlineUploadProps {
    * no notification UI is appropriate.
   */
   viewerUsername?: string;
+  viewerEmail?: string;
   viewerRole?: Role;
   viewerName?: string;
   organizationName?: string;
@@ -91,6 +92,7 @@ export default function DocumentsInlineUpload({
   alert,
   onUploadComplete,
   viewerUsername,
+  viewerEmail,
   viewerRole,
   viewerName,
   organizationName,
@@ -135,7 +137,7 @@ export default function DocumentsInlineUpload({
   // Notify flow
   const canNotify = !!viewerUsername
     && viewerUsername !== targetUser
-    && canUseClientNotifications(viewerRole, organizationName, viewerUsername);
+    && canUseClientNotifications(viewerRole, organizationName, viewerUsername, viewerEmail);
   const [showNotifyConfirm, setShowNotifyConfirm] = useState(false);
   const [clientDisplayName, setClientDisplayName] = useState<string>(clientNameProp || '');
   const [clientPhone, setClientPhone] = useState<string>('');

--- a/src/components/Documents/MyDocuments.tsx
+++ b/src/components/Documents/MyDocuments.tsx
@@ -24,6 +24,7 @@ interface OwnProps {
   username: string;
   clientName?: string;
   viewerUsername?: string;
+  viewerEmail?: string;
   viewerName?: string;
   organizationName?: string;
 }
@@ -506,6 +507,7 @@ class MyDocuments extends Component<Props, State> {
         this.props.viewerRole,
         this.props.organizationName,
         this.props.viewerUsername,
+        this.props.viewerEmail,
       )
     ) {
       actions.push({
@@ -644,6 +646,7 @@ class MyDocuments extends Component<Props, State> {
       this.props.viewerRole || this.props.userRole,
       this.props.organizationName,
       this.props.viewerUsername || this.props.username,
+      this.props.viewerEmail,
     );
 
     return (
@@ -654,6 +657,7 @@ class MyDocuments extends Component<Props, State> {
               userRole={currentUserRole}
               viewerRole={this.props.viewerRole}
               viewerUsername={this.props.viewerUsername}
+              viewerEmail={this.props.viewerEmail}
               organizationName={this.props.organizationName}
               documentId={currentDocumentId}
               documentName={currentDocumentName}
@@ -733,6 +737,7 @@ class MyDocuments extends Component<Props, State> {
                     </h1>
                   )}
                   viewerUsername={this.isStaffViewer() ? this.props.viewerUsername : undefined}
+                  viewerEmail={this.isStaffViewer() ? this.props.viewerEmail : undefined}
                   viewerRole={this.isStaffViewer() ? this.props.viewerRole : undefined}
                   viewerName={this.isStaffViewer() ? this.props.viewerName : undefined}
                   organizationName={this.isStaffViewer() ? this.props.organizationName : undefined}

--- a/src/components/Documents/ViewDocument.tsx
+++ b/src/components/Documents/ViewDocument.tsx
@@ -26,6 +26,7 @@ interface Props {
   clientName?: string;
   viewerRole?: Role;
   viewerUsername?: string;
+  viewerEmail?: string;
   organizationName?: string;
   onDownloadCurrentDocument: () => void;
   onRequestDeleteCurrentDocument: () => void;
@@ -48,6 +49,7 @@ const ViewDocument: React.FC<Props> = ({
   clientName,
   viewerRole,
   viewerUsername,
+  viewerEmail,
   organizationName,
   onDownloadCurrentDocument,
   onRequestDeleteCurrentDocument,
@@ -103,7 +105,12 @@ const ViewDocument: React.FC<Props> = ({
   const isStaffViewer = viewerRole === Role.Worker
     || viewerRole === Role.Admin
     || viewerRole === Role.Director;
-  const canNotify = isStaffViewer && canUseClientNotifications(viewerRole, organizationName, viewerUsername);
+  const canNotify = isStaffViewer && canUseClientNotifications(
+    viewerRole,
+    organizationName,
+    viewerUsername,
+    viewerEmail,
+  );
 
   const uploadedAtLabel = (() => {
     if (!documentDate) return '';

--- a/src/components/Header.fixture.tsx
+++ b/src/components/Header.fixture.tsx
@@ -34,6 +34,7 @@ function HeaderFixture({ isLoggedIn, role }: Props) {
       role={role}
       organization="Team Keep"
       username="demo@keep.id"
+      email="demo@keep.id"
       alert={alert}
     />
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,24 +14,28 @@ interface Props {
     role: Role,
     username: string,
     organization: string,
-    name: string
+    name: string,
+    email?: string,
   ) => void;
   logOut: () => void;
   isLoggedIn: boolean;
   role: Role;
   organization: string;
   username: string;
+  email: string;
   alert: any;
 }
 
 interface State {}
 
 // We extend React.Component with Props & State
-function Header({ logIn, logOut, isLoggedIn, role, organization, username, alert }: Props) {
+function Header({
+  logIn, logOut, isLoggedIn, role, organization, username, email, alert,
+}: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const isStaffUser = role === Role.Admin || role === Role.Director || role === Role.Worker;
-  const showApplicationsLink = isStaffUser && canUseApplications(role, organization, username);
-  const showCommunicationsLink = canUseCommunications(role, organization, username);
+  const showApplicationsLink = isStaffUser && canUseApplications(role, organization, username, email);
+  const showCommunicationsLink = canUseCommunications(role, organization, username, email);
 
   // Updated NavLink
   const NavLink = ({ to, children }: { to: string; children: React.ReactNode }) => (

--- a/src/components/Home/HeroAuthSection.tsx
+++ b/src/components/Home/HeroAuthSection.tsx
@@ -11,7 +11,8 @@ interface HeroAuthSectionProps {
     role: Role,
     username: string,
     organization: string,
-    name: string
+    name: string,
+    email?: string,
   ) => void;
   logOut?: () => void;
   role?: Role;

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -32,7 +32,8 @@ interface HomeProps {
     role: Role,
     username: string,
     organization: string,
-    name: string
+    name: string,
+    email?: string,
   ) => void;
   logOut?: () => void;
   role?: Role;

--- a/src/components/LandingPages/ClientDashboardSummaryCards.tsx
+++ b/src/components/LandingPages/ClientDashboardSummaryCards.tsx
@@ -124,14 +124,16 @@ interface Props {
   role: Role;
   organization: string;
   username: string;
+  email: string;
 }
 
 export default function ClientDashboardSummaryCards({
   role,
   organization,
   username,
+  email,
 }: Props): React.ReactElement {
-  const canAccessApplications = canUseApplications(role, organization, username);
+  const canAccessApplications = canUseApplications(role, organization, username, email);
   const [documents, setDocuments] = useState<CountLoadState>({ status: 'loading' });
   const [applications, setApplications] = useState<CountLoadState>({
     status: 'loading',

--- a/src/components/LandingPages/ClientLanding.tsx
+++ b/src/components/LandingPages/ClientLanding.tsx
@@ -11,11 +11,14 @@ import ClientDashboardSummaryCards from './ClientDashboardSummaryCards';
 interface Props extends RouteComponentProps {
   name: String;
   username: string;
+  email: string;
   role: Role;
   organization: string;
 }
 
-function ClientLanding({ role, organization, username }: Props): React.ReactElement {
+function ClientLanding({
+  role, organization, username, email,
+}: Props): React.ReactElement {
   return (
     <div id="Buttons" className="container pt-5">
       <Helmet>
@@ -25,7 +28,12 @@ function ClientLanding({ role, organization, username }: Props): React.ReactElem
       <div className="mb-3">
         <QuickAccessCards />
       </div>
-      <ClientDashboardSummaryCards role={role} organization={organization} username={username} />
+      <ClientDashboardSummaryCards
+        role={role}
+        organization={organization}
+        username={username}
+        email={email}
+      />
     </div>
   );
 }

--- a/src/components/LandingPages/WorkerLanding.tsx
+++ b/src/components/LandingPages/WorkerLanding.tsx
@@ -15,6 +15,7 @@ import IdPickupNotificationForm from '../Notifications/IdPickupNotificationForm'
 
 interface Props {
   username: string;
+  email: string;
   name: string;
   organization: string;
   role: Role;
@@ -115,7 +116,9 @@ function sortClients(list: TargetClient[], mode: ClientSortMode): TargetClient[]
 const CARD_CLIENTS_PER_PAGE = 6;
 const LIST_CLIENTS_PER_PAGE = 15;
 
-const WorkerLanding: React.FC<Props> = ({ username, name, organization, role, logOut, alert }) => {
+const WorkerLanding: React.FC<Props> = ({
+  username, email, name, organization, role, logOut, alert,
+}) => {
   const history = useHistory();
   const [clients, setClients] = useState<TargetClient[]>([]);
   const [searchName, setSearchName] = useState('');
@@ -131,9 +134,9 @@ const WorkerLanding: React.FC<Props> = ({ username, name, organization, role, lo
   const [viewMode, setViewMode] = useState<ClientViewMode>('list');
   const [isLoading, setIsLoading] = useState(true);
   const { path } = useRouteMatch();
-  const canAccessApplications = canUseApplications(role, organization, username);
-  const canAccessCommunications = canUseCommunications(role, organization, username);
-  const canAccessNotifications = canUseClientNotifications(role, organization, username);
+  const canAccessApplications = canUseApplications(role, organization, username, email);
+  const canAccessCommunications = canUseCommunications(role, organization, username, email);
+  const canAccessNotifications = canUseClientNotifications(role, organization, username, email);
 
   const loadProfilePhoto = useCallback(async (clientsArray: TargetClient[], signal: AbortSignal) => {
     const clientsWithPhoto = clientsArray.filter((client) => client.profilePhoto != null);

--- a/src/components/Profile/ProfilePage.tsx
+++ b/src/components/Profile/ProfilePage.tsx
@@ -24,6 +24,7 @@ type Props = {
   viewerRole?: Role;
   viewerOrganization?: string;
   viewerUsername?: string;
+  viewerEmail?: string;
 };
 
 export type NameObj = {
@@ -76,6 +77,7 @@ export default function ProfilePage({
   viewerRole,
   viewerOrganization,
   viewerUsername,
+  viewerEmail,
 }: Props) {
   const alert = useAlert();
   const history = useHistory();
@@ -96,18 +98,32 @@ export default function ProfilePage({
           role: parsed.role as Role,
           organization: parsed.organization as string,
           username: parsed.username as string,
+          email: (parsed.email || '') as string,
         };
       }
     } catch { /* ignore */ }
-    return { role: '', organization: '', username: '' };
+    return {
+      role: '', organization: '', username: '', email: '',
+    };
   }, []);
   const currentUserRole = viewerRole || currentUserSession.role;
   const currentUserOrganization = viewerOrganization || currentUserSession.organization;
   const currentUsername = viewerUsername || currentUserSession.username;
+  const currentEmail = viewerEmail || currentUserSession.email;
 
   const isAdmin = currentUserRole === Role.Admin || currentUserRole === Role.Director;
-  const canAccessApplications = canUseApplications(currentUserRole, currentUserOrganization, currentUsername);
-  const canAccessCommunicationHistory = canUseCommunications(currentUserRole, currentUserOrganization, currentUsername);
+  const canAccessApplications = canUseApplications(
+    currentUserRole,
+    currentUserOrganization,
+    currentUsername,
+    currentEmail,
+  );
+  const canAccessCommunicationHistory = canUseCommunications(
+    currentUserRole,
+    currentUserOrganization,
+    currentUsername,
+    currentEmail,
+  );
 
   const canEditClientIdentityFields = useMemo(
     () =>

--- a/src/components/UserAuthentication/LoginPage.tsx
+++ b/src/components/UserAuthentication/LoginPage.tsx
@@ -31,7 +31,8 @@ interface Props {
     role: Role,
     username: string,
     organization: string,
-    name: string
+    name: string,
+    email?: string,
   ) => void;
   logOut: () => void;
   isLoggedIn: boolean;
@@ -140,7 +141,13 @@ class LoginPage extends Component<Props, State> {
                   return Role.LoggedOut;
               }
             };
-            logIn(role(), resolvedUsername || username, organization, `${firstName} ${lastName}`);
+            logIn(
+              role(),
+              resolvedUsername || username,
+              organization,
+              `${firstName} ${lastName}`,
+              username.includes('@') ? username : '',
+            );
           } else if (status === 'AUTH_FAILURE') {
             alert.show('Incorrect email or password');
             this.clearInput();

--- a/src/utils/featureAccess.test.ts
+++ b/src/utils/featureAccess.test.ts
@@ -20,6 +20,10 @@ describe('feature access policy', () => {
     expect(hasFullFeatureIdentityOverride('danieljoo@keep.id')).toBe(true);
     expect(hasFullFeatureIdentityOverride(' ConnorChong+dev@keep.id ')).toBe(true);
     expect(hasFullFeatureIdentityOverride('steffencornwell')).toBe(true);
+    expect(hasFullFeatureIdentityOverride(
+      'unrelated-internal-username',
+      'steffencornwell+demo@gmail.com',
+    )).toBe(true);
     expect(hasFullFeatureIdentityOverride('team.danieljoo@keep.id')).toBe(false);
   });
 
@@ -32,6 +36,12 @@ describe('feature access policy', () => {
 
   it('allows applications for approved full-feature identities outside Team Keep', () => {
     expect(canUseApplications(Role.Admin, 'Demo Org', 'danieljoo@keep.id')).toBe(true);
+    expect(canUseApplications(
+      Role.Admin,
+      'Demo Org',
+      'unrelated-internal-username',
+      'steffencornwell+applications@gmail.com',
+    )).toBe(true);
     expect(canUseApplications(Role.LoggedOut, 'Demo Org', 'danieljoo@keep.id')).toBe(false);
   });
 
@@ -45,6 +55,12 @@ describe('feature access policy', () => {
 
   it('allows communications for approved full-feature staff identities outside Team Keep', () => {
     expect(canUseCommunications(Role.Worker, 'Demo Org', 'connorchong@keep.id')).toBe(true);
+    expect(canUseCommunications(
+      Role.Worker,
+      'Demo Org',
+      'unrelated-internal-username',
+      'steffencornwell+communications@gmail.com',
+    )).toBe(true);
     expect(canUseCommunications(Role.Client, 'Demo Org', 'connorchong@keep.id')).toBe(false);
   });
 

--- a/src/utils/featureAccess.ts
+++ b/src/utils/featureAccess.ts
@@ -18,16 +18,20 @@ export function isTeamKeepOrganization(organization?: string | null): boolean {
   return FULL_FEATURE_ORG_NAMES.some((name) => normalizedOrganizationName(name) === normalized);
 }
 
-export function hasFullFeatureIdentityOverride(identity?: string | null): boolean {
-  const normalized = normalizedIdentity(identity);
-  return FULL_FEATURE_IDENTITY_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+export function hasFullFeatureIdentityOverride(
+  ...identities: Array<string | null | undefined>
+): boolean {
+  return identities.some((identity) => {
+    const normalized = normalizedIdentity(identity);
+    return FULL_FEATURE_IDENTITY_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+  });
 }
 
 function canUseFullFeatureOrganization(
   organization?: string | null,
-  identity?: string | null,
+  identities: Array<string | null | undefined> = [],
 ): boolean {
-  return isTeamKeepOrganization(organization) || hasFullFeatureIdentityOverride(identity);
+  return isTeamKeepOrganization(organization) || hasFullFeatureIdentityOverride(...identities);
 }
 
 export function isAdminRole(role: RoleLike): boolean {
@@ -45,23 +49,23 @@ function isSignedInRole(role: RoleLike): boolean {
 export function canUseApplications(
   role: RoleLike,
   organization?: string | null,
-  identity?: string | null,
+  ...identities: Array<string | null | undefined>
 ): boolean {
-  return isSignedInRole(role) && canUseFullFeatureOrganization(organization, identity);
+  return isSignedInRole(role) && canUseFullFeatureOrganization(organization, identities);
 }
 
 export function canUseCommunications(
   role: RoleLike,
   organization?: string | null,
-  identity?: string | null,
+  ...identities: Array<string | null | undefined>
 ): boolean {
-  return isStaffRole(role) && canUseFullFeatureOrganization(organization, identity);
+  return isStaffRole(role) && canUseFullFeatureOrganization(organization, identities);
 }
 
 export function canUseClientNotifications(
   role: RoleLike,
   organization?: string | null,
-  identity?: string | null,
+  ...identities: Array<string | null | undefined>
 ): boolean {
-  return isAdminRole(role) && canUseFullFeatureOrganization(organization, identity);
+  return isAdminRole(role) && canUseFullFeatureOrganization(organization, identities);
 }


### PR DESCRIPTION
## Summary
- Hydrate the signed-in account email from the existing profile endpoint and retain it in client session state.
- Evaluate both the internal username and account email for the full-feature access override.
- Thread the email identity through Applications, Communications, profile, dashboard, and document feature checks.

## Verification
- `npx vitest run src/utils/featureAccess.test.ts`
- `npm run lint:ts` (passes with existing warnings)
- `npm run build`
- `git diff --check`

## Screenshots
- Not applicable; access-policy change only.

## Notes
- Root cause: the client claimed to support username/email prefixes but only passed the server's internal username to the policy helper. Accounts whose email starts with `steffencornwell+` therefore missed the override when their internal username differed.
- Existing role restrictions are preserved: Communications still requires a staff role, notifications still require admin/director, and logged-out users remain denied.
- `npx tsc --noEmit` continues to report pre-existing repository errors in unrelated scanner, interactive-form, and fixture code; it reported no errors in the changed feature-access paths.
