### PR TITLE
Use fixed text for selector information components

### DIFF
--- a/src/components/Applications/applicationSelector/ApplicationSelectorFlow.tsx
+++ b/src/components/Applications/applicationSelector/ApplicationSelectorFlow.tsx
@@ -435,14 +435,14 @@ const ApplicationSelectorFlow = ({
               className="tw-mb-5 tw-rounded-md tw-border tw-border-blue-300 tw-bg-white tw-px-4 tw-py-2 tw-font-semibold tw-text-blue-700 hover:tw-bg-blue-50"
               onClick={() => setHomelessnessDefinitionOpen(true)}
             >
-              {String(config.label || 'Click here for definition of homelessness')}
+              Click here for definition of homelessness
             </button>
           );
         }
         if (node.componentKey === 'penndot-login-details') {
           return (
             <div className="tw-mb-5 tw-max-w-2xl tw-rounded-lg tw-border tw-border-slate-200 tw-bg-slate-50 tw-p-5 tw-text-slate-950">
-              <p className="tw-mb-3 tw-font-semibold">{String(config.label || 'Log in with')}</p>
+              <p className="tw-mb-3 tw-font-semibold">Log in with</p>
               <dl className="tw-grid tw-gap-2 sm:tw-grid-cols-[auto_1fr]">
                 <dt className="tw-font-medium">Photo ID number:</dt>
                 <dd className="tw-font-mono">{clientLoginDetailsLoading ? 'Loading…' : (clientLoginDetails.penndotNumber || 'Not saved')}</dd>


### PR DESCRIPTION
## Summary
- Render the homelessness-definition button and PennDOT-login heading with their built-in text.
- Stop treating those fixed informational components as author-labeled fields.

## Verification
- `npm run build`
- `npm run lint:ts` (19 existing warnings, 0 errors)
- `npm run lint:scss`

## Screenshots
- The worker-facing appearance is unchanged; see the companion developer portal PR for the simplified authoring UI.

## Notes
- This follows merged PR #676 and contains only the fixed-component cleanup.
