### PR TITLE
Fix standard application form handoff

### DIFF
--- a/src/components/Applications/ViewApplications.tsx
+++ b/src/components/Applications/ViewApplications.tsx
@@ -509,7 +509,7 @@ class ViewApplications extends Component<Props & RouteComponentProps, State, {}>
                 idType: application.idType,
                 housingStatus: application.housingStatus,
               },
-              startAtReview: true,
+              startAtWebForm: true,
             },
           }}
           className="tw-flex tw-items-center tw-justify-between tw-gap-4 tw-border-b tw-border-gray-200 tw-bg-white tw-px-4 tw-py-3 tw-text-sm tw-no-underline last:tw-border-b-0 hover:tw-bg-blue-50"


### PR DESCRIPTION
## Summary
- Update the standard application list to send the current `startAtWebForm` handoff flag.
- Ensure preset applications load their registry/PDF identifier after a worker selects a client instead of getting stuck on “Could not load this application.”

## Verification
- `npm run build`
- `npm run lint:ts` (0 errors; 19 existing warnings)
- `npx vitest run` (41 tests passed)

## Screenshots
- Not applicable; this is a routing-state fix with no visual changes.

## Notes
- Root cause: the application handoff flag was renamed, but the standard application list still sent the obsolete `startAtReview` flag. The application picker already used the current flag.
