### PR TITLE
Prevent stale PWA releases across browser profiles

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,12 +6,15 @@ import { createRoot } from 'react-dom/client';
 import './static/styles/main.scss'
 import 'bootstrap/dist/css/bootstrap.min.css';
 import App from './App';
+import { registerServiceWorker } from './lib/pwa/registerServiceWorker';
 
 import { Buffer } from 'buffer';
 window.Buffer = Buffer;
 
 import process from 'process';
 window.process = process;
+
+registerServiceWorker();
 
 // console.log(Buffer.from('hello').toString('base64')); // should log: aGVsbG8=
 

--- a/src/lib/pwa/README.md
+++ b/src/lib/pwa/README.md
@@ -48,7 +48,8 @@ feature. The matching UI lives in `src/components/InstallPrompt/`.
 | Nudge shows even though user dismissed it | `useDismissalMemory.ts` |
 | Nudge never re-appears after dismissal | `useDismissalMemory.ts` (currently uses sessionStorage on purpose) |
 | Need to change app name / icons / shortcuts | `vite.pwa.config.ts` (project root, NOT here) |
-| Service worker never registers | `vite.pwa.config.ts` and run `npm run build` (SW only registers in production builds by default) |
+| Service worker never registers | `registerServiceWorker.js`, `vite.pwa.config.ts`, and run `npm run build` (SW only registers in production builds by default) |
+| Different profiles show different releases | Confirm `registerServiceWorker.js` is reloading on activation and that the worker does not precache HTML / JS / CSS |
 
 ## Debugging tips
 
@@ -67,7 +68,9 @@ feature. The matching UI lives in `src/components/InstallPrompt/`.
 
 ## Privacy note
 
-The service worker (`vite.pwa.config.ts` → `workbox`) intentionally caches
-**only the static app shell** — JS, CSS, HTML, icons. We do **not** cache API
-responses or user documents. Caching PII would be a regression on Keep.ID's
-threat model. Do not add API runtime caching here without a security review.
+The service worker intentionally does **not** cache the application shell, API
+responses, or user documents. Browsers fetch the current HTML, JavaScript, and
+CSS from every deployment; only the manifest icons listed in
+`vite.pwa.config.ts` are precached. Caching PII would be a regression on
+Keep.ID's threat model. Do not add API runtime caching here without a security
+review.

--- a/src/lib/pwa/registerServiceWorker.js
+++ b/src/lib/pwa/registerServiceWorker.js
@@ -1,0 +1,18 @@
+import { registerSW } from 'virtual:pwa-register';
+
+/**
+ * Register through Workbox's update-aware client instead of the generated
+ * one-line registration script. In auto-update mode this reloads the page
+ * when a newly deployed worker activates, so the current tab cannot continue
+ * rendering an older JavaScript/CSS bundle under the new worker.
+ */
+export const registerServiceWorker = () => {
+  registerSW({
+    immediate: true,
+    onRegisterError(error) {
+      // A registration failure should never prevent the main application
+      // from loading, but it should remain diagnosable in browser logs.
+      console.error('[PWA] Service worker registration failed.', error);
+    },
+  });
+};

--- a/vite.pwa.config.ts
+++ b/vite.pwa.config.ts
@@ -3,7 +3,7 @@
  *
  * This file is the single source of truth for:
  *  - The Web App Manifest (name, icons, colors, shortcuts, display mode)
- *  - The Service Worker / Workbox precache + runtime caching strategy
+ *  - The Service Worker / Workbox caching strategy
  *
  * Edit this file when:
  *  - Changing the installed-app name, icon, or theme colors
@@ -11,17 +11,20 @@
  *  - Adjusting offline caching behavior
  *
  * IMPORTANT — privacy:
- *  The runtime cache is intentionally limited to the static app shell
- *  (HTML / JS / CSS / icons). We do NOT cache API responses or user
- *  documents in the service worker. Caching PII would be a regression
- *  on Keep.ID's threat model.
+ *  The service worker intentionally does not cache the application shell,
+ *  API responses, or user documents. Each visit must load the current HTML,
+ *  JavaScript, and CSS from the server so separate browser profiles cannot
+ *  remain on different releases. Caching PII would also be a regression on
+ *  Keep.ID's threat model.
  */
 
 import type { VitePWAOptions } from 'vite-plugin-pwa';
 
 export const pwaConfig: Partial<VitePWAOptions> = {
   registerType: 'autoUpdate',
-  injectRegister: 'auto',
+  // Registration is handled in src/lib/pwa/registerServiceWorker.js so the
+  // page reloads as soon as an updated worker takes control.
+  injectRegister: false,
   includeAssets: [
     'favicon.ico',
     'favicon-16x16.png',
@@ -83,21 +86,12 @@ export const pwaConfig: Partial<VitePWAOptions> = {
     ],
   },
   workbox: {
-    // Precache the built app shell. Keep this list narrow on purpose.
-    globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2}'],
-    // The main bundle is ~3.5 MB today (Bootstrap + jsonforms + react-pdf, etc.).
-    // Bump this if the bundle grows further; consider code-splitting instead.
-    maximumFileSizeToCacheInBytes: 6 * 1024 * 1024,
-    // SPA fallback — any unknown route returns index.html so React Router can handle it offline.
-    navigateFallback: '/index.html',
-    navigateFallbackDenylist: [
-      // API + auth routes must hit the network, never the cache.
-      /^\/api\//,
-      /^\/login/,
-      /^\/logout/,
-      /^\/authenticate/,
-    ],
-    // No runtimeCaching for API/document responses — see privacy note above.
+    // Do not precache the app shell. The explicitly listed manifest icons
+    // above remain available to the installed PWA, while all UI code and
+    // styling are fetched from the current deployment.
+    globPatterns: [],
+    navigateFallback: null,
+    // No runtime caching for API/document responses or application assets.
     runtimeCaching: [],
     cleanupOutdatedCaches: true,
   },


### PR DESCRIPTION
## Summary
- Replace the generated one-line service-worker registration with the update-aware Workbox client.
- Reload the page when a newly deployed worker activates.
- Stop precaching the application HTML, JavaScript, CSS, and application assets.
- Retain PWA installation support and precaching for manifest icons.

## Verification
- `npm run build`
- `npm run lint:ts` (passes with 19 existing warnings)
- `npm run lint:scss`
- Inspected the generated `dist/sw.js`: its precache contains only 13 manifest/icon entries and no app-shell bundle.
- Inspected the production bundle: it contains the Workbox activation listener and reload behavior.

## Screenshots
- Not applicable; this changes release caching and update behavior without changing the visible UI.

## Notes
- The first deployment may still require one final reload for a profile already controlled by the old worker. After the new worker takes control, outdated app-shell cache entries are removed and future worker activations reload automatically.
- Direct SPA routes continue to work online through the existing nginx fallback. Offline app-shell navigation is intentionally removed so workers cannot remain on different frontend releases.