### PR TITLE
Remove county from client enrollment

### DIFF
--- a/src/components/Applications/ApplicationForm.tsx
+++ b/src/components/Applications/ApplicationForm.tsx
@@ -1024,15 +1024,6 @@ export default function ApplicationForm({
                             />
                           </Form.Group>
                         </div>
-                        <Form.Group controlId="newClientMailAddressCounty">
-                          <Form.Label>County (optional)</Form.Label>
-                          <Form.Control
-                            className={whoForInputClassName}
-                            name="mailAddressCounty"
-                            value={enrollForm.mailAddress.county}
-                            onChange={(e) => handleEnrollMailingAddressChange('county', e.target.value)}
-                          />
-                        </Form.Group>
                       </div>
                     </div>
                     <div className="tw-mt-3">

--- a/src/components/SignUp/EnrollClient.tsx
+++ b/src/components/SignUp/EnrollClient.tsx
@@ -617,19 +617,6 @@ export default function EnrollClientPage(): JSX.Element {
                       />
                     </div>
                   </div>
-                  <div>
-                    <label htmlFor="mailAddressCounty" className="tw-block tw-text-sm tw-font-medium tw-text-gray-700 tw-mb-1">
-                      County <span className="tw-text-gray-400 tw-font-normal">(optional)</span>
-                    </label>
-                    <input
-                      id="mailAddressCounty"
-                      type="text"
-                      placeholder="County"
-                      className={inputClassName}
-                      value={values.mailAddress.county}
-                      onChange={(e) => onMailingAddressChange('county', e.target.value)}
-                    />
-                  </div>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
- Remove the optional County field from the dedicated Enroll Client page.
- Remove the same field from inline client enrollment within an application.
- Preserve county support in existing profiles, saved data, and form directives.

## Verification
- `npm run build`
- `npx eslint src/components/SignUp/EnrollClient.tsx src/components/Applications/ApplicationForm.tsx`

## Screenshots
- Not captured; this PR only removes the County row and was published immediately as requested.

## Notes
- Existing county values are not deleted or modified.
